### PR TITLE
fix(api): Advanced API Performance Optimization (#107)

### DIFF
--- a/databases/clients/billingClient.ts
+++ b/databases/clients/billingClient.ts
@@ -1,9 +1,10 @@
 import { PrismaClient as BillingPrismaClient } from '../../node_modules/.prisma/billing-client';
+import { buildOptimizedDatabaseUrl } from './urlOptimizer';
 
 const billingClient = new BillingPrismaClient({
   datasources: {
     db: {
-      url: process.env.BILLING_SERVICE_DATABASE_URL,
+      url: buildOptimizedDatabaseUrl(process.env.BILLING_SERVICE_DATABASE_URL),
     },
   },
 });

--- a/databases/clients/paymentClient.ts
+++ b/databases/clients/paymentClient.ts
@@ -1,9 +1,10 @@
 import { PrismaClient as PaymentPrismaClient } from '../../node_modules/.prisma/payment-client';
+import { buildOptimizedDatabaseUrl } from './urlOptimizer';
 
 const paymentClient = new PaymentPrismaClient({
   datasources: {
     db: {
-      url: process.env.PAYMENT_SERVICE_DATABASE_URL,
+      url: buildOptimizedDatabaseUrl(process.env.PAYMENT_SERVICE_DATABASE_URL),
     },
   },
 });

--- a/databases/clients/urlOptimizer.ts
+++ b/databases/clients/urlOptimizer.ts
@@ -1,0 +1,36 @@
+const parsePositiveInt = (value: string | undefined, fallback: number): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const setIfMissing = (url: URL, key: string, value: string) => {
+  if (!url.searchParams.has(key)) {
+    url.searchParams.set(key, value);
+  }
+};
+
+export const buildOptimizedDatabaseUrl = (rawUrl: string | undefined): string | undefined => {
+  if (!rawUrl) {
+    return rawUrl;
+  }
+
+  try {
+    const url = new URL(rawUrl);
+
+    const connectionLimit = parsePositiveInt(process.env.DB_CONNECTION_LIMIT, 20);
+    const poolTimeout = parsePositiveInt(process.env.DB_POOL_TIMEOUT_SECONDS, 15);
+    const connectTimeout = parsePositiveInt(process.env.DB_CONNECT_TIMEOUT_SECONDS, 10);
+
+    setIfMissing(url, 'connection_limit', String(connectionLimit));
+    setIfMissing(url, 'pool_timeout', String(poolTimeout));
+    setIfMissing(url, 'connect_timeout', String(connectTimeout));
+
+    if (process.env.DB_USE_PGBOUNCER === 'true') {
+      setIfMissing(url, 'pgbouncer', 'true');
+    }
+
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+};

--- a/databases/clients/userClient.ts
+++ b/databases/clients/userClient.ts
@@ -1,9 +1,10 @@
 import { PrismaClient as UserPrismaClient } from '../../node_modules/.prisma/user-client';
+import { buildOptimizedDatabaseUrl } from './urlOptimizer';
 
 const userClient = new UserPrismaClient({
   datasources: {
     db: {
-      url: process.env.USER_SERVICE_DATABASE_URL,
+      url: buildOptimizedDatabaseUrl(process.env.USER_SERVICE_DATABASE_URL),
     },
   },
 });

--- a/databases/payment-service/schema.prisma
+++ b/databases/payment-service/schema.prisma
@@ -30,4 +30,5 @@ model Payment {
   @@index([transactionId])
   @@index([status])
   @@index([createdAt])
+  @@index([userId, createdAt(sort: Desc)])
 }

--- a/microservices/README.md
+++ b/microservices/README.md
@@ -45,6 +45,9 @@ Each service exposes `/health` endpoint:
 - etc.
 
 Gateway aggregates all health checks at `http://localhost:3000/health`
+Gateway performance metrics:
+- JSON metrics: `http://localhost:3000/metrics`
+- Prometheus metrics: `http://localhost:3000/metrics/prometheus`
 
 ## Environment Variables
 
@@ -58,6 +61,24 @@ UTILITY_SERVICE_PORT=3006
 ANALYTICS_SERVICE_PORT=3007
 WEBHOOK_SERVICE_PORT=3008
 API_GATEWAY_PORT=3000
+
+# Gateway performance tuning
+GATEWAY_REQUEST_TIMEOUT_MS=4000
+GATEWAY_CACHE_TTL_MS=10000
+GATEWAY_CACHE_MAX_ENTRIES=1000
+GATEWAY_MAX_SOCKETS=2048
+GATEWAY_MAX_FREE_SOCKETS=256
+GATEWAY_KEEP_ALIVE_MS=5000
+GATEWAY_SLOW_REQUEST_THRESHOLD_MS=500
+
+# Optional CDN redirect for /assets/*
+CDN_BASE_URL=https://cdn.example.com
+
+# Prisma connection pooling defaults
+DB_CONNECTION_LIMIT=20
+DB_POOL_TIMEOUT_SECONDS=15
+DB_CONNECT_TIMEOUT_SECONDS=10
+DB_USE_PGBOUNCER=false
 ```
 
 ## Migration Benefits

--- a/microservices/api-gateway/index.ts
+++ b/microservices/api-gateway/index.ts
@@ -1,13 +1,37 @@
-import express from 'express';
-import axios from 'axios';
+import express, { Request, Response, NextFunction } from 'express';
+import axios, { AxiosError, AxiosInstance, Method } from 'axios';
+import { responseCompression } from '../shared/middleware/responseCompression';
+import { Agent as HttpAgent } from 'http';
+import { Agent as HttpsAgent } from 'https';
 import { errorHandler } from '../shared/middleware/errorHandler';
 
+type ServiceMap = Record<string, string>;
+
+interface CacheEntry {
+  body: unknown;
+  status: number;
+  expiresAt: number;
+  headers: Record<string, string>;
+}
+
+interface GatewayStats {
+  totalRequests: number;
+  proxiedRequests: number;
+  cacheHits: number;
+  cacheMisses: number;
+  upstreamErrors: number;
+  latenciesMs: number[];
+}
+
 const app = express();
-const PORT = process.env.API_GATEWAY_PORT || 3000;
+const PORT = Number(process.env.API_GATEWAY_PORT || 3000);
+const REQUEST_TIMEOUT_MS = Number(process.env.GATEWAY_REQUEST_TIMEOUT_MS || 4000);
+const CACHE_TTL_MS = Number(process.env.GATEWAY_CACHE_TTL_MS || 10_000);
+const MAX_LATENCY_SAMPLES = Number(process.env.GATEWAY_MAX_LATENCY_SAMPLES || 5000);
+const MAX_CACHE_SIZE = Number(process.env.GATEWAY_CACHE_MAX_ENTRIES || 1000);
+const SLOW_REQUEST_THRESHOLD_MS = Number(process.env.GATEWAY_SLOW_REQUEST_THRESHOLD_MS || 500);
 
-app.use(express.json());
-
-const services = {
+const services: ServiceMap = {
   user: process.env.USER_SERVICE_URL || 'http://localhost:3001',
   payment: process.env.PAYMENT_SERVICE_URL || 'http://localhost:3002',
   billing: process.env.BILLING_SERVICE_URL || 'http://localhost:3003',
@@ -18,46 +42,339 @@ const services = {
   webhook: process.env.WEBHOOK_SERVICE_URL || 'http://localhost:3008',
 };
 
-app.get('/health', async (req, res) => {
+const httpAgent = new HttpAgent({
+  keepAlive: true,
+  maxSockets: Number(process.env.GATEWAY_MAX_SOCKETS || 2048),
+  maxFreeSockets: Number(process.env.GATEWAY_MAX_FREE_SOCKETS || 256),
+  timeout: REQUEST_TIMEOUT_MS,
+  keepAliveMsecs: Number(process.env.GATEWAY_KEEP_ALIVE_MS || 5000),
+});
+
+const httpsAgent = new HttpsAgent({
+  keepAlive: true,
+  maxSockets: Number(process.env.GATEWAY_MAX_SOCKETS || 2048),
+  maxFreeSockets: Number(process.env.GATEWAY_MAX_FREE_SOCKETS || 256),
+  timeout: REQUEST_TIMEOUT_MS,
+  keepAliveMsecs: Number(process.env.GATEWAY_KEEP_ALIVE_MS || 5000),
+});
+
+const upstreamClient: AxiosInstance = axios.create({
+  timeout: REQUEST_TIMEOUT_MS,
+  httpAgent,
+  httpsAgent,
+  validateStatus: () => true,
+  transitional: {
+    clarifyTimeoutError: true,
+  },
+});
+
+const responseCache = new Map<string, CacheEntry>();
+const stats: GatewayStats = {
+  totalRequests: 0,
+  proxiedRequests: 0,
+  cacheHits: 0,
+  cacheMisses: 0,
+  upstreamErrors: 0,
+  latenciesMs: [],
+};
+
+app.use(express.json({ limit: '1mb' }));
+app.use(responseCompression(1024));
+
+app.use((req: Request, res: Response, next: NextFunction) => {
+  const start = performance.now();
+  stats.totalRequests += 1;
+
+  res.on('finish', () => {
+    const latency = performance.now() - start;
+    stats.latenciesMs.push(latency);
+
+    if (stats.latenciesMs.length > MAX_LATENCY_SAMPLES) {
+      stats.latenciesMs = stats.latenciesMs.slice(-MAX_LATENCY_SAMPLES);
+    }
+
+    if (latency > SLOW_REQUEST_THRESHOLD_MS) {
+      console.warn('[gateway] slow request', {
+        method: req.method,
+        path: req.originalUrl,
+        status: res.statusCode,
+        latencyMs: Number(latency.toFixed(2)),
+      });
+    }
+  });
+
+  next();
+});
+
+const getCacheKey = (req: Request) => `${req.method}:${req.originalUrl}`;
+
+const trimCache = () => {
+  if (responseCache.size <= MAX_CACHE_SIZE) {
+    return;
+  }
+
+  const oldestKey = responseCache.keys().next().value;
+  if (oldestKey) {
+    responseCache.delete(oldestKey);
+  }
+};
+
+const readCached = (req: Request): CacheEntry | null => {
+  if (req.method !== 'GET') {
+    return null;
+  }
+
+  const key = getCacheKey(req);
+  const cached = responseCache.get(key);
+
+  if (!cached) {
+    stats.cacheMisses += 1;
+    return null;
+  }
+
+  if (cached.expiresAt <= Date.now()) {
+    responseCache.delete(key);
+    stats.cacheMisses += 1;
+    return null;
+  }
+
+  stats.cacheHits += 1;
+  return cached;
+};
+
+const cacheResponse = (req: Request, status: number, body: unknown, headers: Record<string, string>) => {
+  if (req.method !== 'GET' || status >= 400) {
+    return;
+  }
+
+  const key = getCacheKey(req);
+  responseCache.set(key, {
+    body,
+    status,
+    headers,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+
+  trimCache();
+};
+
+const sanitizeForwardHeaders = (req: Request): Record<string, string> => {
+  const forwardedHeaders: Record<string, string> = {
+    'x-forwarded-for': req.ip,
+    'x-forwarded-proto': req.protocol,
+    'x-request-id': (req.headers['x-request-id'] as string) || '',
+  };
+
+  const allowedHeaders = ['authorization', 'content-type', 'accept', 'accept-language', 'user-agent'];
+
+  for (const headerName of allowedHeaders) {
+    const headerValue = req.headers[headerName];
+    if (typeof headerValue === 'string' && headerValue.length > 0) {
+      forwardedHeaders[headerName] = headerValue;
+    }
+  }
+
+  return forwardedHeaders;
+};
+
+const collectOutboundHeaders = (headers: Record<string, unknown>): Record<string, string> => {
+  const passthrough: Record<string, string> = {};
+  const headerWhitelist = ['cache-control', 'content-type', 'etag', 'last-modified'];
+
+  for (const key of headerWhitelist) {
+    const value = headers[key];
+    if (typeof value === 'string') {
+      passthrough[key] = value;
+    }
+  }
+
+  return passthrough;
+};
+
+const percentile = (values: number[], p: number): number => {
+  if (values.length === 0) {
+    return 0;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[index];
+};
+
+const renderPrometheusMetrics = (): string => {
+  const avgLatency = stats.latenciesMs.length
+    ? stats.latenciesMs.reduce((sum, value) => sum + value, 0) / stats.latenciesMs.length
+    : 0;
+
+  const p50 = percentile(stats.latenciesMs, 50);
+  const p95 = percentile(stats.latenciesMs, 95);
+  const p99 = percentile(stats.latenciesMs, 99);
+  const cacheLookups = stats.cacheHits + stats.cacheMisses;
+  const cacheHitRatio = cacheLookups > 0 ? stats.cacheHits / cacheLookups : 0;
+
+  return [
+    '# HELP gateway_requests_total Total number of requests handled by gateway',
+    '# TYPE gateway_requests_total counter',
+    `gateway_requests_total ${stats.totalRequests}`,
+    '# HELP gateway_proxied_requests_total Total number of proxied upstream requests',
+    '# TYPE gateway_proxied_requests_total counter',
+    `gateway_proxied_requests_total ${stats.proxiedRequests}`,
+    '# HELP gateway_upstream_errors_total Total number of upstream request errors',
+    '# TYPE gateway_upstream_errors_total counter',
+    `gateway_upstream_errors_total ${stats.upstreamErrors}`,
+    '# HELP gateway_cache_hits_total Total number of gateway cache hits',
+    '# TYPE gateway_cache_hits_total counter',
+    `gateway_cache_hits_total ${stats.cacheHits}`,
+    '# HELP gateway_cache_misses_total Total number of gateway cache misses',
+    '# TYPE gateway_cache_misses_total counter',
+    `gateway_cache_misses_total ${stats.cacheMisses}`,
+    '# HELP gateway_cache_hit_ratio Current gateway cache hit ratio',
+    '# TYPE gateway_cache_hit_ratio gauge',
+    `gateway_cache_hit_ratio ${cacheHitRatio}`,
+    '# HELP gateway_cache_entries Current number of items in gateway cache',
+    '# TYPE gateway_cache_entries gauge',
+    `gateway_cache_entries ${responseCache.size}`,
+    '# HELP gateway_latency_average_ms Average gateway request latency in milliseconds',
+    '# TYPE gateway_latency_average_ms gauge',
+    `gateway_latency_average_ms ${avgLatency.toFixed(4)}`,
+    '# HELP gateway_latency_p50_ms P50 gateway request latency in milliseconds',
+    '# TYPE gateway_latency_p50_ms gauge',
+    `gateway_latency_p50_ms ${p50.toFixed(4)}`,
+    '# HELP gateway_latency_p95_ms P95 gateway request latency in milliseconds',
+    '# TYPE gateway_latency_p95_ms gauge',
+    `gateway_latency_p95_ms ${p95.toFixed(4)}`,
+    '# HELP gateway_latency_p99_ms P99 gateway request latency in milliseconds',
+    '# TYPE gateway_latency_p99_ms gauge',
+    `gateway_latency_p99_ms ${p99.toFixed(4)}`,
+  ].join('\n');
+};
+
+const proxyToService = (serviceKey: keyof typeof services, upstreamBasePath: string) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const serviceUrl = services[serviceKey];
+
+    const cached = readCached(req);
+    if (cached) {
+      Object.entries(cached.headers).forEach(([name, value]) => res.setHeader(name, value));
+      res.setHeader('x-cache', 'HIT');
+      res.status(cached.status).json(cached.body);
+      return;
+    }
+
+    try {
+      stats.proxiedRequests += 1;
+      const method = req.method as Method;
+      const targetPath = req.url === '/' ? '' : req.url;
+      const targetUrl = `${serviceUrl}${upstreamBasePath}${targetPath}`;
+
+      const upstreamResponse = await upstreamClient.request({
+        method,
+        url: targetUrl,
+        data: req.body,
+        headers: sanitizeForwardHeaders(req),
+      });
+
+      const passthroughHeaders = collectOutboundHeaders(upstreamResponse.headers as Record<string, unknown>);
+      Object.entries(passthroughHeaders).forEach(([name, value]) => res.setHeader(name, value));
+      res.setHeader('x-cache', 'MISS');
+
+      if (upstreamResponse.status >= 500) {
+        stats.upstreamErrors += 1;
+      }
+
+      cacheResponse(req, upstreamResponse.status, upstreamResponse.data, passthroughHeaders);
+
+      res.status(upstreamResponse.status).json(upstreamResponse.data);
+    } catch (error) {
+      stats.upstreamErrors += 1;
+      const axiosError = error as AxiosError;
+      const statusCode = axiosError.response?.status || 502;
+
+      next({
+        statusCode,
+        code: 'UPSTREAM_REQUEST_FAILED',
+        message: `Failed to proxy request to ${serviceKey} service`,
+        details: {
+          service: serviceKey,
+          target: services[serviceKey],
+          reason: axiosError.message,
+        },
+      });
+    }
+  };
+};
+
+app.get('/health', async (_req, res) => {
   const health = await Promise.all(
     Object.entries(services).map(async ([name, url]) => {
       try {
-        await axios.get(`${url}/health`, { timeout: 2000 });
-        return { service: name, status: 'UP' };
+        const response = await upstreamClient.get(`${url}/health`, { timeout: 1500 });
+        return { service: name, status: response.status < 500 ? 'UP' : 'DEGRADED' };
       } catch {
         return { service: name, status: 'DOWN' };
       }
     })
   );
+
   res.json({ gateway: 'UP', services: health });
 });
 
-app.use('/api/users', async (req, res, next) => {
-  try {
-    const response = await axios({ method: req.method, url: `${services.user}${req.path}`, data: req.body });
-    res.json(response.data);
-  } catch (error: any) {
-    next(error);
-  }
+app.get('/metrics', (_req: Request, res: Response) => {
+  const avgLatency = stats.latenciesMs.length
+    ? stats.latenciesMs.reduce((sum, value) => sum + value, 0) / stats.latenciesMs.length
+    : 0;
+
+  const hitRatio = stats.cacheHits + stats.cacheMisses > 0
+    ? (stats.cacheHits / (stats.cacheHits + stats.cacheMisses)) * 100
+    : 0;
+
+  res.json({
+    requests: {
+      total: stats.totalRequests,
+      proxied: stats.proxiedRequests,
+      upstreamErrors: stats.upstreamErrors,
+    },
+    latencyMs: {
+      average: Number(avgLatency.toFixed(2)),
+      p50: Number(percentile(stats.latenciesMs, 50).toFixed(2)),
+      p95: Number(percentile(stats.latenciesMs, 95).toFixed(2)),
+      p99: Number(percentile(stats.latenciesMs, 99).toFixed(2)),
+    },
+    cache: {
+      entries: responseCache.size,
+      hitRatio: Number(hitRatio.toFixed(2)),
+      ttlMs: CACHE_TTL_MS,
+    },
+    connections: {
+      maxSockets: httpAgent.maxSockets,
+      maxFreeSockets: httpAgent.maxFreeSockets,
+    },
+  });
 });
 
-app.use('/api/payments', async (req, res, next) => {
-  try {
-    const response = await axios({ method: req.method, url: `${services.payment}${req.path}`, data: req.body });
-    res.json(response.data);
-  } catch (error: any) {
-    next(error);
-  }
+app.get('/metrics/prometheus', (_req: Request, res: Response) => {
+  res.setHeader('Content-Type', 'text/plain; version=0.0.4');
+  res.send(renderPrometheusMetrics());
 });
 
-app.use('/api/bills', async (req, res, next) => {
-  try {
-    const response = await axios({ method: req.method, url: `${services.billing}${req.path}`, data: req.body });
-    res.json(response.data);
-  } catch (error: any) {
-    next(error);
+// CDN integration endpoint for static assets (optional)
+app.get('/assets/*', (req: Request, res: Response, next: NextFunction) => {
+  const cdnBaseUrl = process.env.CDN_BASE_URL;
+
+  if (!cdnBaseUrl) {
+    res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    next();
+    return;
   }
+
+  const assetPath = req.path.replace('/assets', '');
+  const normalizedBase = cdnBaseUrl.endsWith('/') ? cdnBaseUrl.slice(0, -1) : cdnBaseUrl;
+  res.redirect(302, `${normalizedBase}${assetPath}`);
 });
+
+app.use('/api/users', proxyToService('user', '/users'));
+app.use('/api/payments', proxyToService('payment', '/payments'));
+app.use('/api/bills', proxyToService('billing', '/bills'));
 
 app.use(errorHandler);
 

--- a/microservices/payment-service/index.ts
+++ b/microservices/payment-service/index.ts
@@ -1,33 +1,58 @@
 import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import { responseCompression } from '../shared/middleware/responseCompression';
 import { paymentClient } from '../../databases/clients';
 import EventBus from '../../databases/event-patterns/EventBus';
 import MessageBroker from '../../databases/event-patterns/MessageBroker';
 import { createPaymentSuccessEvent, createPaymentFailedEvent } from '../../databases/event-patterns/events';
 import { errorHandler } from '../shared/middleware/errorHandler';
+import { requestIdMiddleware } from '../shared/middleware/requestId';
 import { sendSuccess, sendError } from '../shared/utils/response';
 import '../../databases/event-patterns/handlers';
 
 const app = express();
-const PORT = process.env.PAYMENT_SERVICE_PORT || 3002;
+const PORT = Number(process.env.PAYMENT_SERVICE_PORT || 3002);
 
-app.use(express.json());
+app.use(helmet());
+app.use(cors());
+app.use(responseCompression(1024));
+app.use(express.json({ limit: '1mb' }));
+app.use(requestIdMiddleware('payment-service'));
 
-app.get('/health', (req, res) => {
-  res.json({ status: 'UP', service: 'payment-service', timestamp: new Date().toISOString() });
+app.get('/health', async (_req, res) => {
+  try {
+    await paymentClient.$queryRaw`SELECT 1`;
+    res.json({ status: 'UP', service: 'payment-service', timestamp: new Date().toISOString() });
+  } catch {
+    sendError(res, 'HEALTH_CHECK_FAILED', 'Service unhealthy', 503);
+  }
 });
 
 app.post('/payments', async (req, res, next) => {
   try {
-    const payment = await paymentClient.payment.create({ data: req.body });
-    const event = createPaymentSuccessEvent(payment.id, req.body.billId, req.body.userId, req.body.amount);
-    
-    // Publish to both in-memory and message broker
+    const payment = await paymentClient.payment.create({
+      data: req.body,
+      select: {
+        id: true,
+        amount: true,
+        method: true,
+        status: true,
+        transactionId: true,
+        billId: true,
+        userId: true,
+        createdAt: true,
+      },
+    });
+
+    const event = createPaymentSuccessEvent(payment.id, payment.billId, payment.userId, Number(payment.amount));
+
     EventBus.publish(event);
     await MessageBroker.publish(event);
-    
+
     sendSuccess(res, payment, 201);
-  } catch (error) {
-    const failEvent = createPaymentFailedEvent(req.body.paymentId, req.body.billId, req.body.userId, error.message);
+  } catch (error: any) {
+    const failEvent = createPaymentFailedEvent(req.body.paymentId, req.body.billId, req.body.userId, error?.message || 'unknown error');
     EventBus.publish(failEvent);
     await MessageBroker.publish(failEvent);
     next(error);
@@ -36,9 +61,53 @@ app.post('/payments', async (req, res, next) => {
 
 app.get('/payments/:id', async (req, res, next) => {
   try {
-    const payment = await paymentClient.payment.findUnique({ where: { id: req.params.id } });
-    if (!payment) return sendError(res, 'PAYMENT_NOT_FOUND', 'Payment not found', 404);
+    const payment = await paymentClient.payment.findUnique({
+      where: { id: req.params.id },
+      select: {
+        id: true,
+        amount: true,
+        method: true,
+        status: true,
+        transactionId: true,
+        billId: true,
+        userId: true,
+        createdAt: true,
+      },
+    });
+
+    if (!payment) {
+      return sendError(res, 'PAYMENT_NOT_FOUND', 'Payment not found', 404);
+    }
+
     sendSuccess(res, payment);
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.get('/payments/user/:userId', async (req, res, next) => {
+  try {
+    const limit = Math.min(Number(req.query.limit || 50), 100);
+    const offset = Math.max(Number(req.query.offset || 0), 0);
+
+    const payments = await paymentClient.payment.findMany({
+      where: { userId: req.params.userId },
+      orderBy: { createdAt: 'desc' },
+      skip: offset,
+      take: limit,
+      select: {
+        id: true,
+        amount: true,
+        method: true,
+        status: true,
+        transactionId: true,
+        billId: true,
+        userId: true,
+        createdAt: true,
+      },
+    });
+
+    sendSuccess(res, payments, 200, { limit, offset });
   } catch (error) {
     next(error);
   }

--- a/microservices/shared/middleware/responseCompression.ts
+++ b/microservices/shared/middleware/responseCompression.ts
@@ -1,0 +1,78 @@
+import { Request, Response, NextFunction } from 'express';
+import { brotliCompressSync, constants, gzipSync } from 'zlib';
+
+const isCompressibleType = (contentType: string | number | string[] | undefined): boolean => {
+  if (typeof contentType !== 'string') {
+    return true;
+  }
+
+  return (
+    contentType.includes('application/json') ||
+    contentType.includes('text/') ||
+    contentType.includes('application/javascript') ||
+    contentType.includes('application/xml')
+  );
+};
+
+export const responseCompression = (thresholdBytes = 1024) => {
+  return (_req: Request, res: Response, next: NextFunction) => {
+    const acceptEncoding = `${res.req.headers['accept-encoding'] || ''}`;
+    const supportsBrotli = acceptEncoding.includes('br');
+    const supportsGzip = acceptEncoding.includes('gzip');
+
+    if (!supportsBrotli && !supportsGzip) {
+      next();
+      return;
+    }
+
+    const encoding = supportsBrotli ? 'br' : 'gzip';
+
+    const originalWrite = res.write.bind(res);
+    const originalEnd = res.end.bind(res);
+
+    const chunks: Buffer[] = [];
+
+    (res.write as unknown) = ((chunk: any, ...args: any[]) => {
+      if (chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+
+      if (args.length > 0 && typeof args[0] === 'function') {
+        args[0]();
+      } else if (args.length > 1 && typeof args[1] === 'function') {
+        args[1]();
+      }
+
+      return true;
+    }) as Response['write'];
+
+    (res.end as unknown) = ((chunk?: any, ...args: any[]) => {
+      if (chunk) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+
+      const payload = Buffer.concat(chunks);
+      const contentType = res.getHeader('content-type');
+
+      if (payload.length < thresholdBytes || !isCompressibleType(contentType)) {
+        return originalEnd(payload, ...args);
+      }
+
+      const compressedPayload = encoding === 'br'
+        ? brotliCompressSync(payload, {
+          params: {
+            [constants.BROTLI_PARAM_QUALITY]: 4,
+          },
+        })
+        : gzipSync(payload, { level: 6 });
+
+      res.setHeader('content-encoding', encoding);
+      res.setHeader('vary', 'Accept-Encoding');
+      res.removeHeader('content-length');
+
+      return originalEnd(compressedPayload, ...args);
+    }) as Response['end'];
+
+    next();
+  };
+};

--- a/microservices/user-service/index.ts
+++ b/microservices/user-service/index.ts
@@ -1,20 +1,46 @@
 import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import { responseCompression } from '../shared/middleware/responseCompression';
 import { userClient } from '../../databases/clients';
 import { errorHandler } from '../shared/middleware/errorHandler';
+import { requestIdMiddleware } from '../shared/middleware/requestId';
 import { sendSuccess, sendError } from '../shared/utils/response';
 
 const app = express();
-const PORT = process.env.USER_SERVICE_PORT || 3001;
+const PORT = Number(process.env.USER_SERVICE_PORT || 3001);
 
-app.use(express.json());
+app.use(helmet());
+app.use(cors());
+app.use(responseCompression(1024));
+app.use(express.json({ limit: '1mb' }));
+app.use(requestIdMiddleware('user-service'));
 
-app.get('/health', (req, res) => {
-  res.json({ status: 'UP', service: 'user-service', timestamp: new Date().toISOString() });
+app.get('/health', async (_req, res) => {
+  try {
+    await userClient.$queryRaw`SELECT 1`;
+    res.json({ status: 'UP', service: 'user-service', timestamp: new Date().toISOString() });
+  } catch {
+    sendError(res, 'HEALTH_CHECK_FAILED', 'Service unhealthy', 503);
+  }
 });
 
 app.post('/users', async (req, res, next) => {
   try {
-    const user = await userClient.user.create({ data: req.body });
+    const user = await userClient.user.create({
+      data: req.body,
+      select: {
+        id: true,
+        email: true,
+        username: true,
+        name: true,
+        role: true,
+        status: true,
+        walletAddress: true,
+        createdAt: true,
+      },
+    });
+
     sendSuccess(res, user, 201);
   } catch (error) {
     next(error);
@@ -23,8 +49,25 @@ app.post('/users', async (req, res, next) => {
 
 app.get('/users/:id', async (req, res, next) => {
   try {
-    const user = await userClient.user.findUnique({ where: { id: req.params.id } });
-    if (!user) return sendError(res, 'USER_NOT_FOUND', 'User not found', 404);
+    const user = await userClient.user.findUnique({
+      where: { id: req.params.id },
+      select: {
+        id: true,
+        email: true,
+        username: true,
+        name: true,
+        role: true,
+        status: true,
+        walletAddress: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    if (!user) {
+      return sendError(res, 'USER_NOT_FOUND', 'User not found', 404);
+    }
+
     sendSuccess(res, user);
   } catch (error) {
     next(error);
@@ -33,7 +76,21 @@ app.get('/users/:id', async (req, res, next) => {
 
 app.put('/users/:id', async (req, res, next) => {
   try {
-    const user = await userClient.user.update({ where: { id: req.params.id }, data: req.body });
+    const user = await userClient.user.update({
+      where: { id: req.params.id },
+      data: req.body,
+      select: {
+        id: true,
+        email: true,
+        username: true,
+        name: true,
+        role: true,
+        status: true,
+        walletAddress: true,
+        updatedAt: true,
+      },
+    });
+
     sendSuccess(res, user);
   } catch (error) {
     next(error);

--- a/observability/config/alert-rules.yml
+++ b/observability/config/alert-rules.yml
@@ -1,5 +1,41 @@
 # Prometheus Alert Rules
 groups:
+  - name: api_gateway_performance
+    interval: 30s
+    rules:
+      - alert: APIGatewayHighP95Latency
+        expr: gateway_latency_p95_ms > 500
+        for: 5m
+        labels:
+          severity: warning
+          category: performance
+          service: api-gateway
+        annotations:
+          summary: "API gateway p95 latency is high"
+          description: "Gateway p95 latency is {{ $value }}ms for more than 5 minutes"
+
+      - alert: APIGatewayHighUpstreamErrors
+        expr: rate(gateway_upstream_errors_total[5m]) > 5
+        for: 5m
+        labels:
+          severity: critical
+          category: errors
+          service: api-gateway
+        annotations:
+          summary: "API gateway upstream errors are high"
+          description: "Gateway upstream error rate is {{ $value }} errors/sec"
+
+      - alert: APIGatewayLowCacheHitRatio
+        expr: gateway_cache_hit_ratio < 0.1
+        for: 15m
+        labels:
+          severity: warning
+          category: performance
+          service: api-gateway
+        annotations:
+          summary: "API gateway cache hit ratio is low"
+          description: "Gateway cache hit ratio dropped below 10% for more than 15 minutes"
+
   - name: service_health
     interval: 30s
     rules:

--- a/observability/config/prometheus.yml
+++ b/observability/config/prometheus.yml
@@ -25,6 +25,13 @@ scrape_configs:
       - targets: ['localhost:9090']
 
   # User Service
+  - job_name: 'api-gateway'
+    static_configs:
+      - targets: ['api-gateway:3000']
+    metrics_path: '/metrics/prometheus'
+    scrape_interval: 10s
+
+  # User Service
   - job_name: 'user-service'
     static_configs:
       - targets: ['user-service:3001']

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "typescript": "^5.2.2",
     "prisma": "^5.6.0",
     "ts-node": "^10.9.1",
-    "@types/axios": "^0.14.0"
+    "@types/axios": "^0.14.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "supertest": "^6.3.3",


### PR DESCRIPTION
## Overview
This PR delivers end-to-end API performance improvements across the microservices gateway and core services to reduce latency, improve throughput under load, and add operational visibility. It introduces gateway connection reuse, response compression, GET caching, optimized query patterns, DB pooling tuning, and production-ready performance monitoring/alerting.

## Related Issue
Closes #107

## Changes

### 🗄️ Database Schema
- **[MODIFY]** `databases/payment-service/schema.prisma`
  - Added composite index: `@@index([userId, createdAt(sort: Desc)])` for faster user payment-history queries.

### ⚙️ Backend Services
- **[MODIFY]** `databases/clients/userClient.ts`
- **[MODIFY]** `databases/clients/paymentClient.ts`
- **[MODIFY]** `databases/clients/billingClient.ts`
  - Wired all to optimized DB URLs (pool/timeout parameters).
- **[NEW]** `databases/clients/urlOptimizer.ts`
  - Added centralized DB URL optimizer for connection pooling settings (`connection_limit`, `pool_timeout`, `connect_timeout`, optional `pgbouncer`).
- **[MODIFY]** `microservices/user-service/index.ts`
  - Added security/compression middleware.
  - Added DB-backed health check.
  - Reduced response payload via explicit field selection.
- **[MODIFY]** `microservices/payment-service/index.ts`
  - Added security/compression middleware.
  - Added DB-backed health check.
  - Reduced payloads via explicit field selection.
  - Added paginated `GET /payments/user/:userId?limit=&offset=`.

### 🌐 API Gateway
- **[MODIFY]** `microservices/api-gateway/index.ts`
  - Added upstream keep-alive connection pooling (HTTP/HTTPS agents).
  - Replaced repeated proxy blocks with unified proxy handler.
  - Added in-memory GET response cache with TTL and capacity controls.
  - Added latency tracking + slow request logging.
  - Added metrics endpoints:
    - `GET /metrics` (JSON)
    - `GET /metrics/prometheus` (Prometheus text format)
  - Added optional CDN redirect support for `/assets/*` via `CDN_BASE_URL`.

### 📈 Observability & Alerting
- **[MODIFY]** `observability/config/prometheus.yml`
  - Added `api-gateway` scrape job for `/metrics/prometheus`.
- **[MODIFY]** `observability/config/alert-rules.yml`
  - Added gateway performance alerts:
    - high p95 latency
    - high upstream error rate
    - low cache hit ratio

### 📚 Documentation
- **[MODIFY]** `microservices/README.md`
  - Documented new metrics endpoints.
  - Added gateway tuning env vars and DB pooling env vars.
- **[MODIFY]** `package.json`
  - Fixed JSON formatting issue (missing comma in `devDependencies`).

## Verification Results

| Acceptance Criteria | Status |
|---|---|
| Reduced request-path overhead (gateway + services) | ✅ |
| Response compression added | ✅ |
| DB query/index optimization implemented | ✅ |
| Connection pooling optimization implemented | ✅ |
| Performance monitoring endpoints added | ✅ |
| Alerting rules for performance regressions added | ✅ |
| CDN integration hook added (`CDN_BASE_URL`) | ✅ |

## How to Test

```bash
# 1) Start microservices
npm run microservices:start

# 2) Health check
curl -s http://localhost:3000/health | jq

# 3) Gateway JSON metrics
curl -s http://localhost:3000/metrics | jq

# 4) Gateway Prometheus metrics
curl -s http://localhost:3000/metrics/prometheus

# 5) Warm/test cache behavior (look for x-cache: MISS then HIT)
curl -i http://localhost:3000/api/users/<user-id>
curl -i http://localhost:3000/api/users/<user-id>

# 6) Payment history pagination test
curl -s "http://localhost:3000/api/payments/user/<user-id>?limit=20&offset=0" | jq

```

### SCREENSHOT OF ALL TEST BELOW ⬇️ 
# 1) Start microservices
npm run microservices:start
<img width="393" height="274" alt="image" src="https://github.com/user-attachments/assets/c7969953-0766-447a-8773-d465cec7eee0" />

# 2) Health check
curl -s http://localhost:3000/health | jq
<img width="662" height="570" alt="image" src="https://github.com/user-attachments/assets/2c45e991-c08b-4206-af2c-af47b9a51445" />

# 3) Gateway JSON metrics
curl -s http://localhost:3000/metrics | jq
<img width="505" height="331" alt="image" src="https://github.com/user-attachments/assets/d421e1ec-382e-493d-84f9-42a2b3a011b4" />


