### PR TITLE
feat: add Alert, Backdrop, Skeleton, and InputGroup components (#318,#319 #320 #321)

### DIFF
--- a/frontend/src/components/Alert.test.tsx
+++ b/frontend/src/components/Alert.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Alert } from './Alert';
+
+describe('Alert', () => {
+  test('renders children', () => {
+    render(<Alert>Something went wrong</Alert>);
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  test('has role="alert" for accessibility', () => {
+    render(<Alert>Message</Alert>);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  test('renders title when provided', () => {
+    render(<Alert title="Error">Details here</Alert>);
+    expect(screen.getByText('Error')).toBeInTheDocument();
+  });
+
+  test('applies variant class', () => {
+    render(<Alert variant="success">OK</Alert>);
+    expect(screen.getByRole('alert')).toHaveClass('alert-success');
+  });
+
+  test('applies destructive variant class', () => {
+    render(<Alert variant="destructive">Oops</Alert>);
+    expect(screen.getByRole('alert')).toHaveClass('alert-destructive');
+  });
+
+  test('applies warning variant class', () => {
+    render(<Alert variant="warning">Watch out</Alert>);
+    expect(screen.getByRole('alert')).toHaveClass('alert-warning');
+  });
+
+  test('applies info variant class', () => {
+    render(<Alert variant="info">FYI</Alert>);
+    expect(screen.getByRole('alert')).toHaveClass('alert-info');
+  });
+
+  test('shows dismiss button when dismissible', () => {
+    render(<Alert dismissible onDismiss={() => {}}>Msg</Alert>);
+    expect(screen.getByRole('button', { name: /dismiss/i })).toBeInTheDocument();
+  });
+
+  test('calls onDismiss when dismiss button clicked', () => {
+    const onDismiss = jest.fn();
+    render(<Alert dismissible onDismiss={onDismiss}>Msg</Alert>);
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not show dismiss button when not dismissible', () => {
+    render(<Alert>Msg</Alert>);
+    expect(screen.queryByRole('button', { name: /dismiss/i })).not.toBeInTheDocument();
+  });
+
+  test('applies size class for sm', () => {
+    render(<Alert size="sm">Small</Alert>);
+    expect(screen.getByRole('alert')).toHaveClass('text-xs');
+  });
+
+  test('applies size class for lg', () => {
+    render(<Alert size="lg">Large</Alert>);
+    expect(screen.getByRole('alert')).toHaveClass('text-base');
+  });
+
+  test('renders custom icon', () => {
+    render(<Alert icon={<span data-testid="custom-icon" />}>Msg</Alert>);
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+
+  test('applies custom className', () => {
+    render(<Alert className="my-custom">Msg</Alert>);
+    expect(screen.getByRole('alert')).toHaveClass('my-custom');
+  });
+});

--- a/frontend/src/components/Alert.tsx
+++ b/frontend/src/components/Alert.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+type AlertVariant = 'default' | 'success' | 'warning' | 'destructive' | 'info';
+type AlertSize = 'sm' | 'md' | 'lg';
+
+interface AlertProps {
+  variant?: AlertVariant;
+  size?: AlertSize;
+  title?: string;
+  children: React.ReactNode;
+  onDismiss?: () => void;
+  dismissible?: boolean;
+  icon?: React.ReactNode;
+  className?: string;
+}
+
+const defaultIcons: Record<AlertVariant, React.ReactNode> = {
+  default: (
+    <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="12" cy="12" r="10" strokeWidth="2" />
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4m0 4h.01" />
+    </svg>
+  ),
+  success: (
+    <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  warning: (
+    <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+    </svg>
+  ),
+  destructive: (
+    <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  info: (
+    <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+};
+
+const sizeClasses: Record<AlertSize, string> = {
+  sm: 'text-xs p-3',
+  md: 'text-sm p-4',
+  lg: 'text-base p-5',
+};
+
+export const Alert: React.FC<AlertProps> = ({
+  variant = 'default',
+  size = 'md',
+  title,
+  children,
+  onDismiss,
+  dismissible = false,
+  icon,
+  className = '',
+}) => {
+  const variantClass = variant === 'default' ? 'alert-default' : `alert-${variant}`;
+  const resolvedIcon = icon !== undefined ? icon : defaultIcons[variant];
+
+  return (
+    <div
+      role="alert"
+      className={`alert ${variantClass} ${sizeClasses[size]} ${className}`}
+    >
+      {resolvedIcon && (
+        <span className="flex-shrink-0 mt-0.5">{resolvedIcon}</span>
+      )}
+      <div className="flex-1 min-w-0">
+        {title && (
+          <p className="font-semibold leading-tight mb-1">{title}</p>
+        )}
+        <div className="leading-relaxed">{children}</div>
+      </div>
+      {(dismissible || onDismiss) && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss alert"
+          className="flex-shrink-0 ml-auto -mr-1 -mt-1 p-1 rounded opacity-70 hover:opacity-100 focus-ring transition-opacity"
+        >
+          <svg width="14" height="14" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/Backdrop.test.tsx
+++ b/frontend/src/components/Backdrop.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Backdrop } from './Backdrop';
+
+describe('Backdrop', () => {
+  afterEach(() => {
+    document.body.style.overflow = '';
+  });
+
+  test('renders when open=true', () => {
+    render(<Backdrop open={true} />);
+    expect(screen.getByTestId('backdrop')).toBeInTheDocument();
+  });
+
+  test('does not render when open=false', () => {
+    render(<Backdrop open={false} />);
+    expect(screen.queryByTestId('backdrop')).not.toBeInTheDocument();
+  });
+
+  test('calls onClick when clicked', () => {
+    const onClick = jest.fn();
+    render(<Backdrop open={true} onClick={onClick} />);
+    fireEvent.click(screen.getByTestId('backdrop'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not call onClick when static=true', () => {
+    const onClick = jest.fn();
+    render(<Backdrop open={true} onClick={onClick} static={true} />);
+    fireEvent.click(screen.getByTestId('backdrop'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('calls onClick on Escape key', () => {
+    const onClick = jest.fn();
+    render(<Backdrop open={true} onClick={onClick} />);
+    fireEvent.keyDown(screen.getByTestId('backdrop'), { key: 'Escape' });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('applies blur variant class', () => {
+    render(<Backdrop open={true} variant="blur" />);
+    expect(screen.getByTestId('backdrop')).toHaveClass('backdrop-blur-sm');
+  });
+
+  test('applies dark variant class', () => {
+    render(<Backdrop open={true} variant="dark" />);
+    expect(screen.getByTestId('backdrop')).toHaveClass('bg-black/80');
+  });
+
+  test('applies light variant class', () => {
+    render(<Backdrop open={true} variant="light" />);
+    expect(screen.getByTestId('backdrop')).toHaveClass('bg-white/60');
+  });
+
+  test('locks body scroll when open', () => {
+    render(<Backdrop open={true} />);
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  test('restores body scroll when closed', () => {
+    const { rerender } = render(<Backdrop open={true} />);
+    expect(document.body.style.overflow).toBe('hidden');
+    rerender(<Backdrop open={false} />);
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  test('renders children', () => {
+    render(<Backdrop open={true}><div data-testid="child">Content</div></Backdrop>);
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  test('applies custom className', () => {
+    render(<Backdrop open={true} className="my-backdrop" />);
+    expect(screen.getByTestId('backdrop')).toHaveClass('my-backdrop');
+  });
+
+  test('has aria-hidden for accessibility', () => {
+    render(<Backdrop open={true} />);
+    expect(screen.getByTestId('backdrop')).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/frontend/src/components/Backdrop.tsx
+++ b/frontend/src/components/Backdrop.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect } from 'react';
+
+type BackdropVariant = 'default' | 'blur' | 'dark' | 'light';
+
+interface BackdropProps {
+  open: boolean;
+  onClick?: () => void;
+  variant?: BackdropVariant;
+  className?: string;
+  children?: React.ReactNode;
+  /** Prevent closing on click */
+  static?: boolean;
+}
+
+const variantStyles: Record<BackdropVariant, string> = {
+  default: 'bg-black/50',
+  blur: 'bg-black/40 backdrop-blur-sm',
+  dark: 'bg-black/80',
+  light: 'bg-white/60 backdrop-blur-sm',
+};
+
+export const Backdrop: React.FC<BackdropProps> = ({
+  open,
+  onClick,
+  variant = 'default',
+  className = '',
+  children,
+  static: isStatic = false,
+}) => {
+  // Lock body scroll when backdrop is open
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleClick = () => {
+    if (!isStatic && onClick) onClick();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape' && !isStatic && onClick) onClick();
+  };
+
+  return (
+    <div
+      role="presentation"
+      aria-hidden="true"
+      data-testid="backdrop"
+      className={`fixed inset-0 ${variantStyles[variant]} transition-opacity duration-300 ${className}`}
+      style={{ zIndex: 'var(--z-modal-backdrop)' as React.CSSProperties['zIndex'] }}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      {children}
+    </div>
+  );
+};

--- a/frontend/src/components/InputGroup.test.tsx
+++ b/frontend/src/components/InputGroup.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { InputGroup } from './InputGroup';
+
+describe('InputGroup', () => {
+  test('renders children', () => {
+    render(
+      <InputGroup>
+        <input placeholder="Enter value" />
+      </InputGroup>
+    );
+    expect(screen.getByPlaceholderText('Enter value')).toBeInTheDocument();
+  });
+
+  test('renders prepend content', () => {
+    render(
+      <InputGroup prepend={<span>$</span>}>
+        <input />
+      </InputGroup>
+    );
+    expect(screen.getByText('$')).toBeInTheDocument();
+  });
+
+  test('renders append content', () => {
+    render(
+      <InputGroup append={<span>.00</span>}>
+        <input />
+      </InputGroup>
+    );
+    expect(screen.getByText('.00')).toBeInTheDocument();
+  });
+
+  test('renders label when provided', () => {
+    render(
+      <InputGroup label="Amount" htmlFor="amount">
+        <input id="amount" />
+      </InputGroup>
+    );
+    expect(screen.getByText('Amount')).toBeInTheDocument();
+  });
+
+  test('associates label with input via htmlFor', () => {
+    render(
+      <InputGroup label="Amount" htmlFor="amount">
+        <input id="amount" />
+      </InputGroup>
+    );
+    const label = screen.getByText('Amount');
+    expect(label).toHaveAttribute('for', 'amount');
+  });
+
+  test('shows error message', () => {
+    render(
+      <InputGroup error="This field is required">
+        <input />
+      </InputGroup>
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('This field is required');
+  });
+
+  test('shows hint text when no error', () => {
+    render(
+      <InputGroup hint="Enter your amount in USD">
+        <input />
+      </InputGroup>
+    );
+    expect(screen.getByText('Enter your amount in USD')).toBeInTheDocument();
+  });
+
+  test('hides hint when error is present', () => {
+    render(
+      <InputGroup error="Required" hint="Some hint">
+        <input />
+      </InputGroup>
+    );
+    expect(screen.queryByText('Some hint')).not.toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  test('applies disabled styles', () => {
+    const { container } = render(
+      <InputGroup disabled>
+        <input />
+      </InputGroup>
+    );
+    const wrapper = container.querySelector('.pointer-events-none');
+    expect(wrapper).toBeInTheDocument();
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(
+      <InputGroup className="my-group">
+        <input />
+      </InputGroup>
+    );
+    expect(container.firstChild).toHaveClass('my-group');
+  });
+
+  test('renders with sm size', () => {
+    render(
+      <InputGroup size="sm" prepend={<span>@</span>}>
+        <input />
+      </InputGroup>
+    );
+    expect(screen.getByText('@').closest('span')).toHaveClass('text-xs');
+  });
+
+  test('renders with lg size', () => {
+    render(
+      <InputGroup size="lg" prepend={<span>@</span>}>
+        <input />
+      </InputGroup>
+    );
+    expect(screen.getByText('@').closest('span')).toHaveClass('text-base');
+  });
+});

--- a/frontend/src/components/InputGroup.tsx
+++ b/frontend/src/components/InputGroup.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+type InputGroupSize = 'sm' | 'md' | 'lg';
+
+interface InputGroupProps {
+  children: React.ReactNode;
+  /** Content prepended before the input (icon, text, button) */
+  prepend?: React.ReactNode;
+  /** Content appended after the input (icon, text, button) */
+  append?: React.ReactNode;
+  size?: InputGroupSize;
+  /** Error message shown below the group */
+  error?: string;
+  /** Helper text shown below the group */
+  hint?: string;
+  /** Label for the group */
+  label?: string;
+  /** Associates label with input via htmlFor */
+  htmlFor?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+const sizeClasses: Record<InputGroupSize, { addon: string; input: string }> = {
+  sm: { addon: 'px-2 py-1.5 text-xs', input: 'py-1.5 text-xs' },
+  md: { addon: 'px-3 py-2 text-sm', input: 'py-2 text-sm' },
+  lg: { addon: 'px-4 py-3 text-base', input: 'py-3 text-base' },
+};
+
+export const InputGroup: React.FC<InputGroupProps> = ({
+  children,
+  prepend,
+  append,
+  size = 'md',
+  error,
+  hint,
+  label,
+  htmlFor,
+  className = '',
+  disabled = false,
+}) => {
+  const { addon, input } = sizeClasses[size];
+  const errorId = htmlFor ? `${htmlFor}-error` : undefined;
+  const hintId = htmlFor ? `${htmlFor}-hint` : undefined;
+
+  const addonBase = `
+    flex items-center flex-shrink-0 border border-border bg-muted text-muted-foreground
+    ${addon} ${disabled ? 'opacity-50' : ''}
+  `.trim();
+
+  return (
+    <div className={`w-full ${className}`}>
+      {label && (
+        <label htmlFor={htmlFor} className="label">
+          {label}
+        </label>
+      )}
+
+      <div
+        className={`flex w-full rounded-md overflow-hidden border border-border focus-within:border-ring focus-within:ring-1 focus-within:ring-ring transition-shadow ${disabled ? 'opacity-50 pointer-events-none' : ''} ${error ? 'border-destructive focus-within:border-destructive focus-within:ring-destructive' : ''}`}
+      >
+        {prepend && (
+          <span className={`${addonBase} border-r border-border rounded-l-md`}>
+            {prepend}
+          </span>
+        )}
+
+        <div className={`flex-1 min-w-0 [&>input]:border-0 [&>input]:rounded-none [&>input]:shadow-none [&>input]:focus:ring-0 [&>input]:${input} [&>input]:w-full`}>
+          {children}
+        </div>
+
+        {append && (
+          <span className={`${addonBase} border-l border-border rounded-r-md`}>
+            {append}
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <p id={errorId} role="alert" className="mt-1 text-xs text-destructive">
+          {error}
+        </p>
+      )}
+      {!error && hint && (
+        <p id={hintId} className="mt-1 text-xs text-muted-foreground">
+          {hint}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/Skeleton.test.tsx
+++ b/frontend/src/components/Skeleton.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Skeleton } from './Skeleton';
+
+describe('Skeleton', () => {
+  test('renders with default text variant', () => {
+    render(<Skeleton />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  test('has aria-busy="true" for accessibility', () => {
+    render(<Skeleton />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  test('has aria-label for screen readers', () => {
+    render(<Skeleton />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Loading');
+  });
+
+  test('renders multiple lines for text variant', () => {
+    const { container } = render(<Skeleton variant="text" lines={3} />);
+    const lines = container.querySelectorAll('.skeleton-text');
+    expect(lines.length).toBe(3);
+  });
+
+  test('last text line is shorter (70% width)', () => {
+    const { container } = render(<Skeleton variant="text" lines={3} />);
+    const lines = container.querySelectorAll('.skeleton-text');
+    const lastLine = lines[lines.length - 1] as HTMLElement;
+    expect(lastLine.style.width).toBe('70%');
+  });
+
+  test('renders avatar variant', () => {
+    const { container } = render(<Skeleton variant="avatar" />);
+    expect(container.querySelector('.skeleton-avatar')).toBeInTheDocument();
+  });
+
+  test('renders card variant', () => {
+    const { container } = render(<Skeleton variant="card" />);
+    expect(container.querySelector('.skeleton-card')).toBeInTheDocument();
+  });
+
+  test('renders button variant', () => {
+    const { container } = render(<Skeleton variant="button" />);
+    expect(container.querySelector('.skeleton-button')).toBeInTheDocument();
+  });
+
+  test('renders input variant', () => {
+    const { container } = render(<Skeleton variant="input" />);
+    expect(container.querySelector('.skeleton-input')).toBeInTheDocument();
+  });
+
+  test('applies custom width and height', () => {
+    render(<Skeleton variant="custom" width={200} height={50} />);
+    const el = screen.getByRole('status');
+    expect(el).toHaveStyle({ width: '200px', height: '50px' });
+  });
+
+  test('applies custom className', () => {
+    render(<Skeleton className="my-skeleton" />);
+    expect(screen.getByRole('status')).toHaveClass('my-skeleton');
+  });
+
+  test('includes sr-only loading text', () => {
+    render(<Skeleton />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+type SkeletonVariant = 'text' | 'avatar' | 'card' | 'button' | 'input' | 'custom';
+
+interface SkeletonProps {
+  variant?: SkeletonVariant;
+  width?: string | number;
+  height?: string | number;
+  /** Number of text lines to render (text variant only) */
+  lines?: number;
+  className?: string;
+  /** Disable animation (respects prefers-reduced-motion automatically via CSS) */
+  animated?: boolean;
+}
+
+const variantClass: Record<SkeletonVariant, string> = {
+  text: 'skeleton skeleton-text',
+  avatar: 'skeleton skeleton-avatar',
+  card: 'skeleton skeleton-card',
+  button: 'skeleton skeleton-button',
+  input: 'skeleton skeleton-input',
+  custom: 'skeleton',
+};
+
+const SingleSkeleton: React.FC<Omit<SkeletonProps, 'lines'>> = ({
+  variant = 'text',
+  width,
+  height,
+  className = '',
+  animated = true,
+}) => {
+  const style: React.CSSProperties = {};
+  if (width) style.width = typeof width === 'number' ? `${width}px` : width;
+  if (height) style.height = typeof height === 'number' ? `${height}px` : height;
+
+  return (
+    <span
+      aria-hidden="true"
+      className={`${variantClass[variant]} ${!animated ? 'animation-none' : ''} ${className}`}
+      style={style}
+    />
+  );
+};
+
+export const Skeleton: React.FC<SkeletonProps> = ({
+  variant = 'text',
+  lines = 3,
+  width,
+  height,
+  className = '',
+  animated = true,
+}) => {
+  if (variant === 'text' && lines > 1) {
+    return (
+      <div
+        role="status"
+        aria-label="Loading"
+        aria-busy="true"
+        className={`space-y-2 ${className}`}
+      >
+        {Array.from({ length: lines }).map((_, i) => (
+          <SingleSkeleton
+            key={i}
+            variant="text"
+            animated={animated}
+            // Last line is shorter for a natural look
+            width={i === lines - 1 ? '70%' : width}
+            height={height}
+          />
+        ))}
+        <span className="sr-only">Loading...</span>
+      </div>
+    );
+  }
+
+  return (
+    <span
+      role="status"
+      aria-label="Loading"
+      aria-busy="true"
+      className={`${variantClass[variant]} ${!animated ? 'animation-none' : ''} ${className}`}
+      style={{
+        width: width ? (typeof width === 'number' ? `${width}px` : width) : undefined,
+        height: height ? (typeof height === 'number' ? `${height}px` : height) : undefined,
+      }}
+    >
+      <span className="sr-only">Loading...</span>
+    </span>
+  );
+};


### PR DESCRIPTION

Closes #318, 
closes #319, 
closes #320, 
closes #321

Implements four missing frontend UI components with full accessibility, variations, and tests.

## Changes

### Alert (#319)
- 5 variants: default, success, warning, destructive, info
- 3 sizes: sm, md, lg
- Dismissible with onDismiss callback
- Built-in SVG icons per variant, supports custom icon override
- \`role=\"alert\"\` for screen readers

### Backdrop (#321)
- 4 variants: default, blur, dark, light
- Locks body scroll when open, restores on close
- Escape key support to dismiss
- Static mode to prevent close-on-click
- \`aria-hidden\` to hide from assistive tech

### Skeleton (#320)
- 6 variants: text, avatar, card, button, input, custom
- Multi-line text mode with natural last-line shortening
- Custom width/height support
- \`role=\"status\"\`, \`aria-busy\`, \`sr-only\` loading text
- Respects \`prefers-reduced-motion\` via existing CSS

### InputGroup (#318)
- Prepend and append addon slots (icons, text, buttons)
- 3 sizes: sm, md, lg
- Label with \`htmlFor\` association
- Error message (\`role=\"alert\"\`) and hint text
- Disabled state

## Testing
Each component includes a co-located \