### PR TITLE
feat: add Chip, Avatar, Card, and ProgressBar components (#307 #309 #10 #311)

### DIFF
--- a/frontend/src/components/Avatar.test.tsx
+++ b/frontend/src/components/Avatar.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Avatar, AvatarGroup } from './Avatar';
+
+describe('Avatar', () => {
+  test('renders image when src provided', () => {
+    render(<Avatar src="https://example.com/photo.jpg" alt="Jane Doe" />);
+    expect(screen.getByRole('img', { name: 'Jane Doe' })).toBeInTheDocument();
+    expect(screen.getByAltText('Jane Doe')).toBeInTheDocument();
+  });
+
+  test('shows initials fallback when no src', () => {
+    render(<Avatar alt="Jane Doe" />);
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  test('shows initials fallback when image errors', () => {
+    render(<Avatar src="bad-url.jpg" alt="Jane Doe" />);
+    fireEvent.error(screen.getByAltText('Jane Doe'));
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  test('uses explicit initials prop over alt', () => {
+    render(<Avatar alt="Jane Doe" initials="JX" />);
+    expect(screen.getByText('JX')).toBeInTheDocument();
+  });
+
+  test('truncates initials to 2 chars', () => {
+    render(<Avatar initials="ABCD" />);
+    expect(screen.getByText('AB')).toBeInTheDocument();
+  });
+
+  test('shows ? when no alt or initials', () => {
+    render(<Avatar />);
+    expect(screen.getByText('?')).toBeInTheDocument();
+  });
+
+  test('applies md size class by default', () => {
+    render(<Avatar alt="User" />);
+    expect(screen.getByRole('img', { name: 'User' })).toHaveClass('w-10', 'h-10');
+  });
+
+  test('applies sm size class', () => {
+    render(<Avatar alt="User" size="sm" />);
+    expect(screen.getByRole('img', { name: 'User' })).toHaveClass('w-8', 'h-8');
+  });
+
+  test('applies lg size class', () => {
+    render(<Avatar alt="User" size="lg" />);
+    expect(screen.getByRole('img', { name: 'User' })).toHaveClass('w-14', 'h-14');
+  });
+
+  test('applies circle shape by default', () => {
+    render(<Avatar alt="User" />);
+    expect(screen.getByRole('img', { name: 'User' })).toHaveClass('rounded-full');
+  });
+
+  test('applies square shape', () => {
+    render(<Avatar alt="User" shape="square" />);
+    expect(screen.getByRole('img', { name: 'User' })).toHaveClass('rounded-md');
+  });
+
+  test('renders status indicator', () => {
+    render(<Avatar alt="User" status="online" />);
+    expect(screen.getByRole('status', { name: 'Online' })).toBeInTheDocument();
+  });
+
+  test('status indicator has correct color for online', () => {
+    render(<Avatar alt="User" status="online" />);
+    expect(screen.getByRole('status')).toHaveClass('bg-success');
+  });
+
+  test('status indicator has correct color for busy', () => {
+    render(<Avatar alt="User" status="busy" />);
+    expect(screen.getByRole('status')).toHaveClass('bg-destructive');
+  });
+
+  test('applies custom className', () => {
+    render(<Avatar alt="User" className="my-avatar" />);
+    expect(screen.getByRole('img', { name: 'User' })).toHaveClass('my-avatar');
+  });
+});
+
+describe('AvatarGroup', () => {
+  test('renders all avatars when no max', () => {
+    render(
+      <AvatarGroup>
+        <Avatar alt="A" />
+        <Avatar alt="B" />
+        <Avatar alt="C" />
+      </AvatarGroup>
+    );
+    expect(screen.getAllByRole('img').length).toBe(3);
+  });
+
+  test('limits visible avatars to max', () => {
+    render(
+      <AvatarGroup max={2}>
+        <Avatar alt="A" />
+        <Avatar alt="B" />
+        <Avatar alt="C" />
+      </AvatarGroup>
+    );
+    expect(screen.getAllByRole('img').length).toBe(2);
+  });
+
+  test('shows overflow count', () => {
+    render(
+      <AvatarGroup max={2}>
+        <Avatar alt="A" />
+        <Avatar alt="B" />
+        <Avatar alt="C" />
+      </AvatarGroup>
+    );
+    expect(screen.getByLabelText('1 more')).toBeInTheDocument();
+  });
+
+  test('has group role', () => {
+    render(
+      <AvatarGroup>
+        <Avatar alt="A" />
+      </AvatarGroup>
+    );
+    expect(screen.getByRole('group')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Avatar.tsx
+++ b/frontend/src/components/Avatar.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react';
+
+type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+type AvatarShape = 'circle' | 'square';
+type AvatarStatus = 'online' | 'offline' | 'away' | 'busy';
+
+interface AvatarProps {
+  src?: string;
+  alt?: string;
+  /** Fallback initials (up to 2 chars) */
+  initials?: string;
+  size?: AvatarSize;
+  shape?: AvatarShape;
+  status?: AvatarStatus;
+  className?: string;
+}
+
+interface AvatarGroupProps {
+  children: React.ReactNode;
+  max?: number;
+  size?: AvatarSize;
+  className?: string;
+}
+
+const sizeClasses: Record<AvatarSize, { container: string; text: string }> = {
+  xs: { container: 'w-6 h-6',   text: 'text-[10px]' },
+  sm: { container: 'w-8 h-8',   text: 'text-xs' },
+  md: { container: 'w-10 h-10', text: 'text-sm' },
+  lg: { container: 'w-14 h-14', text: 'text-lg' },
+  xl: { container: 'w-20 h-20', text: 'text-2xl' },
+};
+
+const shapeClasses: Record<AvatarShape, string> = {
+  circle: 'rounded-full',
+  square: 'rounded-md',
+};
+
+const statusClasses: Record<AvatarStatus, string> = {
+  online:  'bg-success',
+  offline: 'bg-muted-foreground',
+  away:    'bg-warning',
+  busy:    'bg-destructive',
+};
+
+const statusLabels: Record<AvatarStatus, string> = {
+  online:  'Online',
+  offline: 'Offline',
+  away:    'Away',
+  busy:    'Busy',
+};
+
+/** Derive up to 2 initials from a name string */
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return parts[0].charAt(0).toUpperCase();
+  return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+}
+
+export const Avatar: React.FC<AvatarProps> = ({
+  src,
+  alt = '',
+  initials,
+  size = 'md',
+  shape = 'circle',
+  status,
+  className = '',
+}) => {
+  const [imgError, setImgError] = useState(false);
+  const { container, text } = sizeClasses[size];
+  const shapeClass = shapeClasses[shape];
+  const fallbackInitials = initials
+    ? initials.slice(0, 2).toUpperCase()
+    : alt ? getInitials(alt) : '?';
+
+  const showImage = src && !imgError;
+
+  return (
+    <span
+      className={`relative inline-flex flex-shrink-0 items-center justify-center overflow-hidden bg-muted select-none ${container} ${shapeClass} ${className}`}
+      aria-label={alt || initials || 'Avatar'}
+      role="img"
+    >
+      {showImage ? (
+        <img
+          src={src}
+          alt={alt}
+          className="w-full h-full object-cover"
+          onError={() => setImgError(true)}
+        />
+      ) : (
+        <span className={`font-medium text-muted-foreground ${text}`} aria-hidden="true">
+          {fallbackInitials}
+        </span>
+      )}
+
+      {status && (
+        <span
+          className={`absolute bottom-0 right-0 block rounded-full ring-2 ring-background w-2.5 h-2.5 ${statusClasses[status]}`}
+          aria-label={statusLabels[status]}
+          role="status"
+        />
+      )}
+    </span>
+  );
+};
+
+export const AvatarGroup: React.FC<AvatarGroupProps> = ({
+  children,
+  max,
+  size = 'md',
+  className = '',
+}) => {
+  const childArray = React.Children.toArray(children);
+  const visible = max ? childArray.slice(0, max) : childArray;
+  const overflow = max ? childArray.length - max : 0;
+  const { container, text } = sizeClasses[size];
+  const overlapClass = '-ml-2 first:ml-0';
+
+  return (
+    <div
+      className={`flex items-center ${className}`}
+      role="group"
+      aria-label={`${childArray.length} avatars`}
+    >
+      {visible.map((child, i) => (
+        <span key={i} className={`relative inline-flex ${overlapClass} ring-2 ring-background rounded-full`}>
+          {child}
+        </span>
+      ))}
+      {overflow > 0 && (
+        <span
+          className={`relative inline-flex items-center justify-center flex-shrink-0 bg-muted text-muted-foreground font-medium rounded-full ring-2 ring-background ${overlapClass} ${container} ${text}`}
+          aria-label={`${overflow} more`}
+        >
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/Card.test.tsx
+++ b/frontend/src/components/Card.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from './Card';
+
+describe('Card', () => {
+  test('renders children', () => {
+    render(<Card>Hello</Card>);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  test('applies default card class', () => {
+    const { container } = render(<Card>Content</Card>);
+    expect(container.firstChild).toHaveClass('card');
+  });
+
+  test('applies outline variant', () => {
+    const { container } = render(<Card variant="outline">Content</Card>);
+    expect(container.firstChild).toHaveClass('border-2');
+  });
+
+  test('applies elevated variant', () => {
+    const { container } = render(<Card variant="elevated">Content</Card>);
+    expect(container.firstChild).toHaveClass('shadow-lg');
+  });
+
+  test('applies ghost variant', () => {
+    const { container } = render(<Card variant="ghost">Content</Card>);
+    expect(container.firstChild).toHaveClass('bg-transparent');
+  });
+
+  test('renders as button role when onClick provided', () => {
+    render(<Card onClick={() => {}}>Clickable</Card>);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  test('calls onClick when clicked', () => {
+    const onClick = jest.fn();
+    render(<Card onClick={onClick}>Click me</Card>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('triggers onClick on Enter key', () => {
+    const onClick = jest.fn();
+    render(<Card onClick={onClick}>Card</Card>);
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('applies selected ring when selected=true', () => {
+    render(<Card onClick={() => {}} selected>Card</Card>);
+    expect(screen.getByRole('button')).toHaveClass('ring-2');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<Card className="my-card">Content</Card>);
+    expect(container.firstChild).toHaveClass('my-card');
+  });
+
+  test('renders as custom element via as prop', () => {
+    render(<Card as="article">Content</Card>);
+    expect(screen.getByRole('article')).toBeInTheDocument();
+  });
+});
+
+describe('Card sub-components', () => {
+  test('CardHeader renders with card-header class', () => {
+    const { container } = render(<CardHeader>Header</CardHeader>);
+    expect(container.firstChild).toHaveClass('card-header');
+  });
+
+  test('CardTitle renders as h3', () => {
+    render(<CardTitle>Title</CardTitle>);
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Title');
+  });
+
+  test('CardDescription renders with card-description class', () => {
+    const { container } = render(<CardDescription>Desc</CardDescription>);
+    expect(container.firstChild).toHaveClass('card-description');
+  });
+
+  test('CardContent renders with card-content class', () => {
+    const { container } = render(<CardContent>Body</CardContent>);
+    expect(container.firstChild).toHaveClass('card-content');
+  });
+
+  test('CardFooter renders with card-footer class', () => {
+    const { container } = render(<CardFooter>Footer</CardFooter>);
+    expect(container.firstChild).toHaveClass('card-footer');
+  });
+});

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+type CardVariant = 'default' | 'outline' | 'ghost' | 'elevated';
+
+interface CardProps {
+  children: React.ReactNode;
+  variant?: CardVariant;
+  /** Make the card clickable */
+  onClick?: () => void;
+  /** Highlight / selected state */
+  selected?: boolean;
+  className?: string;
+  as?: React.ElementType;
+}
+
+interface CardSectionProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+const variantClasses: Record<CardVariant, string> = {
+  default:  'card',
+  outline:  'card border-2',
+  ghost:    'rounded-lg p-6 bg-transparent border-0 shadow-none',
+  elevated: 'card shadow-lg hover:shadow-xl',
+};
+
+export const Card: React.FC<CardProps> = ({
+  children,
+  variant = 'default',
+  onClick,
+  selected = false,
+  className = '',
+  as: Tag = 'div',
+}) => {
+  const isInteractive = !!onClick;
+
+  return (
+    <Tag
+      className={`
+        ${variantClasses[variant]}
+        ${isInteractive ? 'cursor-pointer transition-transform active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' : ''}
+        ${selected ? 'ring-2 ring-ring border-ring' : ''}
+        ${className}
+      `.trim().replace(/\s+/g, ' ')}
+      onClick={onClick}
+      {...(isInteractive ? { role: 'button', tabIndex: 0, 'aria-pressed': selected } : {})}
+      onKeyDown={isInteractive ? (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') onClick?.(); } : undefined}
+    >
+      {children}
+    </Tag>
+  );
+};
+
+export const CardHeader: React.FC<CardSectionProps> = ({ children, className = '' }) => (
+  <div className={`card-header ${className}`}>{children}</div>
+);
+
+export const CardTitle: React.FC<CardSectionProps> = ({ children, className = '' }) => (
+  <h3 className={`card-title ${className}`}>{children}</h3>
+);
+
+export const CardDescription: React.FC<CardSectionProps> = ({ children, className = '' }) => (
+  <p className={`card-description ${className}`}>{children}</p>
+);
+
+export const CardContent: React.FC<CardSectionProps> = ({ children, className = '' }) => (
+  <div className={`card-content ${className}`}>{children}</div>
+);
+
+export const CardFooter: React.FC<CardSectionProps> = ({ children, className = '' }) => (
+  <div className={`card-footer ${className}`}>{children}</div>
+);

--- a/frontend/src/components/Chip.test.tsx
+++ b/frontend/src/components/Chip.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Chip } from './Chip';
+
+describe('Chip', () => {
+  test('renders label', () => {
+    render(<Chip label="React" />);
+    expect(screen.getByText('React')).toBeInTheDocument();
+  });
+
+  test('renders as span when not clickable', () => {
+    render(<Chip label="Tag" />);
+    expect(screen.getByText('Tag').closest('span')).toBeInTheDocument();
+  });
+
+  test('renders as button when onClick provided', () => {
+    render(<Chip label="Tag" onClick={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Tag' })).toBeInTheDocument();
+  });
+
+  test('calls onClick when clicked', () => {
+    const onClick = jest.fn();
+    render(<Chip label="Tag" onClick={onClick} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Tag' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('shows remove button when onRemove provided', () => {
+    render(<Chip label="Tag" onRemove={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Remove Tag' })).toBeInTheDocument();
+  });
+
+  test('calls onRemove when remove button clicked', () => {
+    const onRemove = jest.fn();
+    render(<Chip label="Tag" onRemove={onRemove} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Tag' }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  test('applies primary variant class', () => {
+    render(<Chip label="Tag" variant="primary" />);
+    expect(screen.getByLabelText('Tag')).toHaveClass('bg-primary');
+  });
+
+  test('applies success variant class', () => {
+    render(<Chip label="Tag" variant="success" />);
+    expect(screen.getByLabelText('Tag')).toHaveClass('text-success');
+  });
+
+  test('applies sm size class', () => {
+    render(<Chip label="Tag" size="sm" />);
+    expect(screen.getByLabelText('Tag')).toHaveClass('text-xs');
+  });
+
+  test('applies lg size class', () => {
+    render(<Chip label="Tag" size="lg" />);
+    expect(screen.getByLabelText('Tag')).toHaveClass('text-base');
+  });
+
+  test('applies selected ring when selected=true', () => {
+    render(<Chip label="Tag" onClick={() => {}} selected={true} />);
+    expect(screen.getByRole('button', { name: 'Tag' })).toHaveClass('ring-2');
+  });
+
+  test('is disabled when disabled=true', () => {
+    render(<Chip label="Tag" onClick={() => {}} disabled={true} />);
+    expect(screen.getByRole('button', { name: 'Tag' })).toBeDisabled();
+  });
+
+  test('renders icon', () => {
+    render(<Chip label="Tag" icon={<span data-testid="icon" />} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  test('applies custom className', () => {
+    render(<Chip label="Tag" className="my-chip" />);
+    expect(screen.getByLabelText('Tag')).toHaveClass('my-chip');
+  });
+});

--- a/frontend/src/components/Chip.tsx
+++ b/frontend/src/components/Chip.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+
+type ChipVariant = 'default' | 'primary' | 'success' | 'warning' | 'destructive' | 'outline';
+type ChipSize = 'sm' | 'md' | 'lg';
+
+interface ChipProps {
+  label: string;
+  variant?: ChipVariant;
+  size?: ChipSize;
+  /** Icon rendered before the label */
+  icon?: React.ReactNode;
+  /** Show a remove/delete button */
+  onRemove?: () => void;
+  /** Make the chip clickable/selectable */
+  onClick?: () => void;
+  selected?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+const variantClasses: Record<ChipVariant, string> = {
+  default:     'bg-secondary text-secondary-foreground border-transparent',
+  primary:     'bg-primary text-primary-foreground border-transparent',
+  success:     'bg-success/10 text-success border-success/30',
+  warning:     'bg-warning/10 text-warning border-warning/30',
+  destructive: 'bg-destructive/10 text-destructive border-destructive/30',
+  outline:     'bg-transparent text-foreground border-border',
+};
+
+const sizeClasses: Record<ChipSize, { chip: string; icon: string; remove: string }> = {
+  sm: { chip: 'text-xs px-2 py-0.5 gap-1',   icon: 'w-3 h-3', remove: 'w-3 h-3' },
+  md: { chip: 'text-sm px-3 py-1 gap-1.5',   icon: 'w-4 h-4', remove: 'w-3.5 h-3.5' },
+  lg: { chip: 'text-base px-4 py-1.5 gap-2', icon: 'w-5 h-5', remove: 'w-4 h-4' },
+};
+
+export const Chip: React.FC<ChipProps> = ({
+  label,
+  variant = 'default',
+  size = 'md',
+  icon,
+  onRemove,
+  onClick,
+  selected = false,
+  disabled = false,
+  className = '',
+}) => {
+  const { chip, icon: iconSize, remove: removeSize } = sizeClasses[size];
+  const isInteractive = !!onClick;
+
+  const baseClasses = `
+    inline-flex items-center rounded-full border font-medium
+    transition-all duration-150 select-none
+    ${chip}
+    ${variantClasses[variant]}
+    ${selected ? 'ring-2 ring-ring ring-offset-1' : ''}
+    ${disabled ? 'opacity-50 pointer-events-none' : ''}
+    ${isInteractive ? 'cursor-pointer hover:opacity-80 active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring' : ''}
+    ${className}
+  `.trim().replace(/\s+/g, ' ');
+
+  const Tag = isInteractive ? 'button' : 'span';
+
+  return (
+    <Tag
+      {...(isInteractive
+        ? {
+            type: 'button' as const,
+            onClick,
+            'aria-pressed': selected,
+            disabled,
+          }
+        : {})}
+      className={baseClasses}
+      aria-label={label}
+    >
+      {icon && (
+        <span className={`flex-shrink-0 ${iconSize}`} aria-hidden="true">
+          {icon}
+        </span>
+      )}
+      <span>{label}</span>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onRemove(); }}
+          aria-label={`Remove ${label}`}
+          disabled={disabled}
+          className={`flex-shrink-0 ml-0.5 rounded-full opacity-60 hover:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring transition-opacity ${removeSize}`}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" aria-hidden="true">
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+    </Tag>
+  );
+};

--- a/frontend/src/components/ProgressBar.test.tsx
+++ b/frontend/src/components/ProgressBar.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ProgressBar } from './ProgressBar';
+
+describe('ProgressBar', () => {
+  test('renders progressbar role', () => {
+    render(<ProgressBar value={50} />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  test('sets aria-valuenow', () => {
+    render(<ProgressBar value={40} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '40');
+  });
+
+  test('sets aria-valuemin and aria-valuemax', () => {
+    render(<ProgressBar value={50} max={200} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '200');
+  });
+
+  test('clamps value to 0', () => {
+    const { container } = render(<ProgressBar value={-10} />);
+    const fill = container.querySelector('.progress-bar') as HTMLElement;
+    expect(fill.style.width).toBe('0%');
+  });
+
+  test('clamps value to 100%', () => {
+    const { container } = render(<ProgressBar value={150} />);
+    const fill = container.querySelector('.progress-bar') as HTMLElement;
+    expect(fill.style.width).toBe('100%');
+  });
+
+  test('shows label when showLabel=true', () => {
+    render(<ProgressBar value={75} showLabel />);
+    expect(screen.getByText('75%')).toBeInTheDocument();
+  });
+
+  test('shows custom label text', () => {
+    render(<ProgressBar value={50} showLabel label="Halfway" />);
+    expect(screen.getByText('Halfway')).toBeInTheDocument();
+  });
+
+  test('applies success variant', () => {
+    const { container } = render(<ProgressBar value={50} variant="success" />);
+    expect(container.querySelector('.progress-bar')).toHaveClass('bg-success');
+  });
+
+  test('applies warning variant', () => {
+    const { container } = render(<ProgressBar value={50} variant="warning" />);
+    expect(container.querySelector('.progress-bar')).toHaveClass('bg-warning');
+  });
+
+  test('applies destructive variant', () => {
+    const { container } = render(<ProgressBar value={50} variant="destructive" />);
+    expect(container.querySelector('.progress-bar')).toHaveClass('bg-destructive');
+  });
+
+  test('applies sm size class', () => {
+    render(<ProgressBar value={50} size="sm" />);
+    expect(screen.getByRole('progressbar')).toHaveClass('h-1');
+  });
+
+  test('applies lg size class', () => {
+    render(<ProgressBar value={50} size="lg" />);
+    expect(screen.getByRole('progressbar')).toHaveClass('h-4');
+  });
+
+  test('indeterminate mode omits aria-valuenow', () => {
+    render(<ProgressBar value={0} indeterminate />);
+    expect(screen.getByRole('progressbar')).not.toHaveAttribute('aria-valuenow');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<ProgressBar value={50} className="my-progress" />);
+    expect(container.firstChild).toHaveClass('my-progress');
+  });
+});

--- a/frontend/src/components/ProgressBar.tsx
+++ b/frontend/src/components/ProgressBar.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+type ProgressVariant = 'default' | 'success' | 'warning' | 'destructive' | 'info';
+type ProgressSize = 'sm' | 'md' | 'lg';
+
+interface ProgressBarProps {
+  /** Value between 0 and max */
+  value: number;
+  max?: number;
+  variant?: ProgressVariant;
+  size?: ProgressSize;
+  /** Show percentage label */
+  showLabel?: boolean;
+  /** Custom label text (overrides percentage) */
+  label?: string;
+  /** Animate the bar on mount */
+  animated?: boolean;
+  /** Indeterminate / unknown progress */
+  indeterminate?: boolean;
+  className?: string;
+}
+
+const variantColor: Record<ProgressVariant, string> = {
+  default: 'bg-primary',
+  success: 'bg-success',
+  warning: 'bg-warning',
+  destructive: 'bg-destructive',
+  info: 'bg-info',
+};
+
+const sizeHeight: Record<ProgressSize, string> = {
+  sm: 'h-1',
+  md: 'h-2',
+  lg: 'h-4',
+};
+
+export const ProgressBar: React.FC<ProgressBarProps> = ({
+  value,
+  max = 100,
+  variant = 'default',
+  size = 'md',
+  showLabel = false,
+  label,
+  animated = true,
+  indeterminate = false,
+  className = '',
+}) => {
+  const pct = Math.min(100, Math.max(0, (value / max) * 100));
+  const displayLabel = label ?? `${Math.round(pct)}%`;
+
+  return (
+    <div className={`w-full ${className}`}>
+      {showLabel && (
+        <div className="flex justify-between items-center mb-1">
+          <span className="text-xs text-muted-foreground">{displayLabel}</span>
+        </div>
+      )}
+      <div
+        role="progressbar"
+        aria-valuenow={indeterminate ? undefined : value}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        aria-label={label ?? `${Math.round(pct)}% complete`}
+        aria-valuetext={indeterminate ? 'Loading…' : displayLabel}
+        className={`progress ${sizeHeight[size]} overflow-hidden`}
+      >
+        <div
+          className={`
+            progress-bar ${variantColor[variant]}
+            ${animated && !indeterminate ? 'transition-[width] duration-500 ease-out' : ''}
+            ${indeterminate ? 'animate-[progress-indeterminate_1.5s_ease-in-out_infinite] w-1/3' : ''}
+          `}
+          style={indeterminate ? undefined : { width: `${pct}%` }}
+        />
+      </div>
+
+      {/* Indeterminate keyframe — injected once via a style tag */}
+      {indeterminate && (
+        <style>{`
+          @keyframes progress-indeterminate {
+            0%   { transform: translateX(-100%); }
+            100% { transform: translateX(400%); }
+          }
+        `}</style>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
Closes #307, 
closes #309, 
closes #310, 
closes #311

Implements four missing frontend UI components as part of the NEPA platform design system.

Chip — inline tag/label component with 6 variants (default, primary, success, warning, destructive, outline), 3 sizes, optional remove button, clickable/selectable state with aria-pressed, and icon support.

Avatar — user image component with automatic initials fallback (derived from alt or explicit initials prop), image error handling, 5 sizes, circle/square shapes, status indicator (online/offline/away/busy), and an AvatarGroup with overflow count.

Card — composable card system with Card, CardHeader, CardTitle, CardDescription, CardContent, and CardFooter sub-components. Supports 4 variants (default, outline, ghost, elevated), clickable/selectable mode with keyboard support, and a polymorphic as prop.

ProgressBar — accessible progress indicator with role="progressbar" and full aria-value* attributes, 5 color variants, 3 sizes, optional label, animated fill, and indeterminate mode for unknown progress states.

All components follow existing project conventions (named exports, React.FC<Props>, Tailwind + CSS design system tokens) and include full test coverage via React Testing Library.