### PR TITLE
feat: add Grid, Divider, Spacer, and Container components (#312 #314 #315 #316)

### DIFF
--- a/frontend/src/components/Container.test.tsx
+++ b/frontend/src/components/Container.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Container } from './Container';
+
+describe('Container', () => {
+  test('renders children', () => {
+    render(<Container>Content</Container>);
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  test('has w-full class', () => {
+    const { container } = render(<Container>Content</Container>);
+    expect(container.firstChild).toHaveClass('w-full');
+  });
+
+  test('centered by default (mx-auto)', () => {
+    const { container } = render(<Container>Content</Container>);
+    expect(container.firstChild).toHaveClass('mx-auto');
+  });
+
+  test('not centered when centered=false', () => {
+    const { container } = render(<Container centered={false}>Content</Container>);
+    expect(container.firstChild).not.toHaveClass('mx-auto');
+  });
+
+  test('applies xl max-width by default', () => {
+    const { container } = render(<Container>Content</Container>);
+    expect(container.firstChild).toHaveClass('max-w-screen-xl');
+  });
+
+  test('applies sm size', () => {
+    const { container } = render(<Container size="sm">Content</Container>);
+    expect(container.firstChild).toHaveClass('max-w-screen-sm');
+  });
+
+  test('applies 2xl size', () => {
+    const { container } = render(<Container size="2xl">Content</Container>);
+    expect(container.firstChild).toHaveClass('max-w-screen-2xl');
+  });
+
+  test('applies full size', () => {
+    const { container } = render(<Container size="full">Content</Container>);
+    expect(container.firstChild).toHaveClass('max-w-full');
+  });
+
+  test('applies md padding by default', () => {
+    const { container } = render(<Container>Content</Container>);
+    expect(container.firstChild).toHaveClass('px-4');
+  });
+
+  test('applies no padding when padding=none', () => {
+    const { container } = render(<Container padding="none">Content</Container>);
+    expect(container.firstChild).not.toHaveClass('px-4');
+  });
+
+  test('applies lg padding', () => {
+    const { container } = render(<Container padding="lg">Content</Container>);
+    expect(container.firstChild).toHaveClass('px-6');
+  });
+
+  test('renders as custom element', () => {
+    render(<Container as="main">Content</Container>);
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<Container className="my-container">Content</Container>);
+    expect(container.firstChild).toHaveClass('my-container');
+  });
+});

--- a/frontend/src/components/Container.tsx
+++ b/frontend/src/components/Container.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+type ContainerSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'full';
+type ContainerPadding = 'none' | 'sm' | 'md' | 'lg';
+
+interface ContainerProps {
+  children: React.ReactNode;
+  size?: ContainerSize;
+  padding?: ContainerPadding;
+  /** Center the container horizontally */
+  centered?: boolean;
+  as?: React.ElementType;
+  className?: string;
+}
+
+const maxWidthClasses: Record<ContainerSize, string> = {
+  sm:   'max-w-screen-sm',
+  md:   'max-w-screen-md',
+  lg:   'max-w-screen-lg',
+  xl:   'max-w-screen-xl',
+  '2xl':'max-w-screen-2xl',
+  full: 'max-w-full',
+};
+
+const paddingClasses: Record<ContainerPadding, string> = {
+  none: '',
+  sm:   'px-4 py-2',
+  md:   'px-4 sm:px-6 lg:px-8',
+  lg:   'px-6 sm:px-8 lg:px-12',
+};
+
+export const Container: React.FC<ContainerProps> = ({
+  children,
+  size = 'xl',
+  padding = 'md',
+  centered = true,
+  as: Tag = 'div',
+  className = '',
+}) => (
+  <Tag
+    className={`
+      w-full
+      ${maxWidthClasses[size]}
+      ${paddingClasses[padding]}
+      ${centered ? 'mx-auto' : ''}
+      ${className}
+    `.trim().replace(/\s+/g, ' ')}
+  >
+    {children}
+  </Tag>
+);

--- a/frontend/src/components/Divider.test.tsx
+++ b/frontend/src/components/Divider.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Divider } from './Divider';
+
+describe('Divider', () => {
+  test('renders a separator', () => {
+    render(<Divider />);
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  test('horizontal orientation by default', () => {
+    render(<Divider />);
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  test('vertical orientation', () => {
+    render(<Divider orientation="vertical" />);
+    expect(screen.getByRole('separator')).toHaveAttribute('aria-orientation', 'vertical');
+  });
+
+  test('applies dashed variant', () => {
+    render(<Divider variant="dashed" />);
+    expect(screen.getByRole('separator')).toHaveClass('border-dashed');
+  });
+
+  test('applies dotted variant', () => {
+    render(<Divider variant="dotted" />);
+    expect(screen.getByRole('separator')).toHaveClass('border-dotted');
+  });
+
+  test('applies thick weight', () => {
+    render(<Divider weight="thick" />);
+    expect(screen.getByRole('separator')).toHaveClass('border-2');
+  });
+
+  test('applies thin weight', () => {
+    render(<Divider weight="thin" />);
+    expect(screen.getByRole('separator')).toHaveClass('border-[0.5px]');
+  });
+
+  test('renders label text', () => {
+    render(<Divider label="OR" />);
+    expect(screen.getByText('OR')).toBeInTheDocument();
+  });
+
+  test('label divider has separator role', () => {
+    render(<Divider label="Section" />);
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  test('applies custom className', () => {
+    render(<Divider className="my-divider" />);
+    expect(screen.getByRole('separator')).toHaveClass('my-divider');
+  });
+
+  test('vertical divider has correct class', () => {
+    render(<Divider orientation="vertical" />);
+    expect(screen.getByRole('separator')).toHaveClass('border-l');
+  });
+});

--- a/frontend/src/components/Divider.tsx
+++ b/frontend/src/components/Divider.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+type DividerOrientation = 'horizontal' | 'vertical';
+type DividerVariant = 'solid' | 'dashed' | 'dotted';
+type DividerWeight = 'thin' | 'base' | 'thick';
+
+interface DividerProps {
+  orientation?: DividerOrientation;
+  variant?: DividerVariant;
+  weight?: DividerWeight;
+  /** Optional label rendered in the middle of a horizontal divider */
+  label?: React.ReactNode;
+  /** Alignment of the label */
+  labelAlign?: 'start' | 'center' | 'end';
+  className?: string;
+}
+
+const borderStyle: Record<DividerVariant, string> = {
+  solid:  'border-solid',
+  dashed: 'border-dashed',
+  dotted: 'border-dotted',
+};
+
+const borderWeight: Record<DividerWeight, string> = {
+  thin:  'border-[0.5px]',
+  base:  'border',
+  thick: 'border-2',
+};
+
+const labelAlignClass: Record<'start' | 'center' | 'end', string> = {
+  start:  'justify-start',
+  center: 'justify-center',
+  end:    'justify-end',
+};
+
+export const Divider: React.FC<DividerProps> = ({
+  orientation = 'horizontal',
+  variant = 'solid',
+  weight = 'base',
+  label,
+  labelAlign = 'center',
+  className = '',
+}) => {
+  const borderClasses = `${borderStyle[variant]} ${borderWeight[weight]} border-border`;
+
+  if (orientation === 'vertical') {
+    return (
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        className={`inline-block self-stretch ${borderClasses} border-l ${className}`}
+      />
+    );
+  }
+
+  if (label) {
+    return (
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        className={`flex items-center gap-3 w-full ${labelAlignClass[labelAlign]} ${className}`}
+      >
+        {labelAlign !== 'start' && (
+          <span className={`flex-1 ${borderClasses} border-t ${labelAlign === 'end' ? 'flex-none w-8' : ''}`} />
+        )}
+        <span className="text-xs text-muted-foreground whitespace-nowrap px-1 select-none">
+          {label}
+        </span>
+        {labelAlign !== 'end' && (
+          <span className={`flex-1 ${borderClasses} border-t ${labelAlign === 'start' ? 'flex-none w-8' : ''}`} />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <hr
+      role="separator"
+      aria-orientation="horizontal"
+      className={`w-full ${borderClasses} border-t border-l-0 border-r-0 border-b-0 m-0 ${className}`}
+    />
+  );
+};

--- a/frontend/src/components/Grid.test.tsx
+++ b/frontend/src/components/Grid.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Grid, GridItem } from './Grid';
+
+describe('Grid', () => {
+  test('renders children', () => {
+    render(<Grid><div>Item</div></Grid>);
+    expect(screen.getByText('Item')).toBeInTheDocument();
+  });
+
+  test('has grid class', () => {
+    const { container } = render(<Grid>content</Grid>);
+    expect(container.firstChild).toHaveClass('grid');
+  });
+
+  test('applies cols class', () => {
+    const { container } = render(<Grid cols={3}>content</Grid>);
+    expect(container.firstChild).toHaveClass('grid-cols-3');
+  });
+
+  test('applies responsive colsMd class', () => {
+    const { container } = render(<Grid cols={1} colsMd={2}>content</Grid>);
+    expect(container.firstChild).toHaveClass('md:grid-cols-2');
+  });
+
+  test('applies responsive colsLg class', () => {
+    const { container } = render(<Grid cols={1} colsLg={4}>content</Grid>);
+    expect(container.firstChild).toHaveClass('lg:grid-cols-4');
+  });
+
+  test('applies gap class', () => {
+    const { container } = render(<Grid gap={4}>content</Grid>);
+    expect(container.firstChild).toHaveClass('gap-4');
+  });
+
+  test('applies gapX class', () => {
+    const { container } = render(<Grid gapX={6}>content</Grid>);
+    expect(container.firstChild).toHaveClass('gap-x-6');
+  });
+
+  test('applies gapY class', () => {
+    const { container } = render(<Grid gapY={2}>content</Grid>);
+    expect(container.firstChild).toHaveClass('gap-y-2');
+  });
+
+  test('renders as custom element', () => {
+    render(<Grid as="section">content</Grid>);
+    expect(screen.getByRole('region')).toBeInTheDocument();
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<Grid className="my-grid">content</Grid>);
+    expect(container.firstChild).toHaveClass('my-grid');
+  });
+});
+
+describe('GridItem', () => {
+  test('renders children', () => {
+    render(<GridItem><span>Cell</span></GridItem>);
+    expect(screen.getByText('Cell')).toBeInTheDocument();
+  });
+
+  test('applies span class', () => {
+    const { container } = render(<GridItem span={6}>Cell</GridItem>);
+    expect(container.firstChild).toHaveClass('col-span-6');
+  });
+
+  test('applies full span class', () => {
+    const { container } = render(<GridItem span="full">Cell</GridItem>);
+    expect(container.firstChild).toHaveClass('col-span-full');
+  });
+
+  test('applies responsive spanMd class', () => {
+    const { container } = render(<GridItem span={12} spanMd={6}>Cell</GridItem>);
+    expect(container.firstChild).toHaveClass('md:col-span-6');
+  });
+
+  test('applies responsive spanLg class', () => {
+    const { container } = render(<GridItem spanLg={4}>Cell</GridItem>);
+    expect(container.firstChild).toHaveClass('lg:col-span-4');
+  });
+
+  test('renders as custom element', () => {
+    render(<GridItem as="article">Cell</GridItem>);
+    expect(screen.getByRole('article')).toBeInTheDocument();
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<GridItem className="my-item">Cell</GridItem>);
+    expect(container.firstChild).toHaveClass('my-item');
+  });
+});

--- a/frontend/src/components/Grid.tsx
+++ b/frontend/src/components/Grid.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+
+type GridCols = 1 | 2 | 3 | 4 | 5 | 6 | 12;
+type GridGap  = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12;
+type ColSpan  = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 'full';
+
+interface GridProps {
+  children: React.ReactNode;
+  /** Columns at each breakpoint */
+  cols?: GridCols;
+  colsSm?: GridCols;
+  colsMd?: GridCols;
+  colsLg?: GridCols;
+  colsXl?: GridCols;
+  gap?: GridGap;
+  gapX?: GridGap;
+  gapY?: GridGap;
+  as?: React.ElementType;
+  className?: string;
+}
+
+interface GridItemProps {
+  children: React.ReactNode;
+  /** Column span at each breakpoint */
+  span?: ColSpan;
+  spanSm?: ColSpan;
+  spanMd?: ColSpan;
+  spanLg?: ColSpan;
+  spanXl?: ColSpan;
+  as?: React.ElementType;
+  className?: string;
+}
+
+const colsClass: Record<GridCols, string> = {
+  1:  'grid-cols-1',
+  2:  'grid-cols-2',
+  3:  'grid-cols-3',
+  4:  'grid-cols-4',
+  5:  'grid-cols-5',
+  6:  'grid-cols-6',
+  12: 'grid-cols-12',
+};
+
+const smColsClass: Record<GridCols, string> = {
+  1:  'sm:grid-cols-1',
+  2:  'sm:grid-cols-2',
+  3:  'sm:grid-cols-3',
+  4:  'sm:grid-cols-4',
+  5:  'sm:grid-cols-5',
+  6:  'sm:grid-cols-6',
+  12: 'sm:grid-cols-12',
+};
+
+const mdColsClass: Record<GridCols, string> = {
+  1:  'md:grid-cols-1',
+  2:  'md:grid-cols-2',
+  3:  'md:grid-cols-3',
+  4:  'md:grid-cols-4',
+  5:  'md:grid-cols-5',
+  6:  'md:grid-cols-6',
+  12: 'md:grid-cols-12',
+};
+
+const lgColsClass: Record<GridCols, string> = {
+  1:  'lg:grid-cols-1',
+  2:  'lg:grid-cols-2',
+  3:  'lg:grid-cols-3',
+  4:  'lg:grid-cols-4',
+  5:  'lg:grid-cols-5',
+  6:  'lg:grid-cols-6',
+  12: 'lg:grid-cols-12',
+};
+
+const xlColsClass: Record<GridCols, string> = {
+  1:  'xl:grid-cols-1',
+  2:  'xl:grid-cols-2',
+  3:  'xl:grid-cols-3',
+  4:  'xl:grid-cols-4',
+  5:  'xl:grid-cols-5',
+  6:  'xl:grid-cols-6',
+  12: 'xl:grid-cols-12',
+};
+
+const gapClass: Record<GridGap, string> = {
+  0: 'gap-0', 1: 'gap-1', 2: 'gap-2', 3: 'gap-3',
+  4: 'gap-4', 5: 'gap-5', 6: 'gap-6', 8: 'gap-8',
+  10: 'gap-10', 12: 'gap-12',
+};
+
+const gapXClass: Record<GridGap, string> = {
+  0: 'gap-x-0', 1: 'gap-x-1', 2: 'gap-x-2', 3: 'gap-x-3',
+  4: 'gap-x-4', 5: 'gap-x-5', 6: 'gap-x-6', 8: 'gap-x-8',
+  10: 'gap-x-10', 12: 'gap-x-12',
+};
+
+const gapYClass: Record<GridGap, string> = {
+  0: 'gap-y-0', 1: 'gap-y-1', 2: 'gap-y-2', 3: 'gap-y-3',
+  4: 'gap-y-4', 5: 'gap-y-5', 6: 'gap-y-6', 8: 'gap-y-8',
+  10: 'gap-y-10', 12: 'gap-y-12',
+};
+
+const spanClass: Record<ColSpan, string> = {
+  1: 'col-span-1', 2: 'col-span-2', 3: 'col-span-3', 4: 'col-span-4',
+  5: 'col-span-5', 6: 'col-span-6', 7: 'col-span-7', 8: 'col-span-8',
+  9: 'col-span-9', 10: 'col-span-10', 11: 'col-span-11', 12: 'col-span-12',
+  full: 'col-span-full',
+};
+
+const smSpanClass: Record<ColSpan, string> = {
+  1: 'sm:col-span-1', 2: 'sm:col-span-2', 3: 'sm:col-span-3', 4: 'sm:col-span-4',
+  5: 'sm:col-span-5', 6: 'sm:col-span-6', 7: 'sm:col-span-7', 8: 'sm:col-span-8',
+  9: 'sm:col-span-9', 10: 'sm:col-span-10', 11: 'sm:col-span-11', 12: 'sm:col-span-12',
+  full: 'sm:col-span-full',
+};
+
+const mdSpanClass: Record<ColSpan, string> = {
+  1: 'md:col-span-1', 2: 'md:col-span-2', 3: 'md:col-span-3', 4: 'md:col-span-4',
+  5: 'md:col-span-5', 6: 'md:col-span-6', 7: 'md:col-span-7', 8: 'md:col-span-8',
+  9: 'md:col-span-9', 10: 'md:col-span-10', 11: 'md:col-span-11', 12: 'md:col-span-12',
+  full: 'md:col-span-full',
+};
+
+const lgSpanClass: Record<ColSpan, string> = {
+  1: 'lg:col-span-1', 2: 'lg:col-span-2', 3: 'lg:col-span-3', 4: 'lg:col-span-4',
+  5: 'lg:col-span-5', 6: 'lg:col-span-6', 7: 'lg:col-span-7', 8: 'lg:col-span-8',
+  9: 'lg:col-span-9', 10: 'lg:col-span-10', 11: 'lg:col-span-11', 12: 'lg:col-span-12',
+  full: 'lg:col-span-full',
+};
+
+const xlSpanClass: Record<ColSpan, string> = {
+  1: 'xl:col-span-1', 2: 'xl:col-span-2', 3: 'xl:col-span-3', 4: 'xl:col-span-4',
+  5: 'xl:col-span-5', 6: 'xl:col-span-6', 7: 'xl:col-span-7', 8: 'xl:col-span-8',
+  9: 'xl:col-span-9', 10: 'xl:col-span-10', 11: 'xl:col-span-11', 12: 'xl:col-span-12',
+  full: 'xl:col-span-full',
+};
+
+export const Grid: React.FC<GridProps> = ({
+  children,
+  cols = 1,
+  colsSm,
+  colsMd,
+  colsLg,
+  colsXl,
+  gap,
+  gapX,
+  gapY,
+  as: Tag = 'div',
+  className = '',
+}) => {
+  const classes = [
+    'grid',
+    colsClass[cols],
+    colsSm  ? smColsClass[colsSm]  : '',
+    colsMd  ? mdColsClass[colsMd]  : '',
+    colsLg  ? lgColsClass[colsLg]  : '',
+    colsXl  ? xlColsClass[colsXl]  : '',
+    gap  !== undefined ? gapClass[gap]   : '',
+    gapX !== undefined ? gapXClass[gapX] : '',
+    gapY !== undefined ? gapYClass[gapY] : '',
+    className,
+  ].filter(Boolean).join(' ');
+
+  return <Tag className={classes}>{children}</Tag>;
+};
+
+export const GridItem: React.FC<GridItemProps> = ({
+  children,
+  span,
+  spanSm,
+  spanMd,
+  spanLg,
+  spanXl,
+  as: Tag = 'div',
+  className = '',
+}) => {
+  const classes = [
+    span   ? spanClass[span]     : '',
+    spanSm ? smSpanClass[spanSm] : '',
+    spanMd ? mdSpanClass[spanMd] : '',
+    spanLg ? lgSpanClass[spanLg] : '',
+    spanXl ? xlSpanClass[spanXl] : '',
+    className,
+  ].filter(Boolean).join(' ');
+
+  return <Tag className={classes}>{children}</Tag>;
+};

--- a/frontend/src/components/Spacer.test.tsx
+++ b/frontend/src/components/Spacer.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Spacer } from './Spacer';
+
+describe('Spacer', () => {
+  test('renders with aria-hidden', () => {
+    render(<Spacer />);
+    expect(screen.getByTestId('spacer')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('default vertical axis sets height', () => {
+    render(<Spacer size={4} axis="vertical" />);
+    const el = screen.getByTestId('spacer');
+    expect(el.style.height).toBe('1rem');
+    expect(el.style.width).toBe('');
+  });
+
+  test('horizontal axis sets width', () => {
+    render(<Spacer size={4} axis="horizontal" />);
+    const el = screen.getByTestId('spacer');
+    expect(el.style.width).toBe('1rem');
+    expect(el.style.height).toBe('');
+  });
+
+  test('both axis sets width and height', () => {
+    render(<Spacer size={8} axis="both" />);
+    const el = screen.getByTestId('spacer');
+    expect(el.style.width).toBe('2rem');
+    expect(el.style.height).toBe('2rem');
+  });
+
+  test('flex mode sets flex style', () => {
+    render(<Spacer flex />);
+    expect(screen.getByTestId('spacer')).toHaveStyle({ flex: '1 1 auto' });
+  });
+
+  test('size 1 maps to 0.25rem', () => {
+    render(<Spacer size={1} />);
+    expect(screen.getByTestId('spacer').style.height).toBe('0.25rem');
+  });
+
+  test('size 16 maps to 4rem', () => {
+    render(<Spacer size={16} />);
+    expect(screen.getByTestId('spacer').style.height).toBe('4rem');
+  });
+
+  test('size 32 maps to 8rem', () => {
+    render(<Spacer size={32} />);
+    expect(screen.getByTestId('spacer').style.height).toBe('8rem');
+  });
+
+  test('applies custom className', () => {
+    render(<Spacer className="my-spacer" />);
+    expect(screen.getByTestId('spacer')).toHaveClass('my-spacer');
+  });
+});

--- a/frontend/src/components/Spacer.tsx
+++ b/frontend/src/components/Spacer.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+type SpacerSize = 1 | 2 | 3 | 4 | 5 | 6 | 8 | 10 | 12 | 16 | 20 | 24 | 32;
+type SpacerAxis = 'vertical' | 'horizontal' | 'both';
+
+interface SpacerProps {
+  /** Size token matching the design system spacing scale */
+  size?: SpacerSize;
+  axis?: SpacerAxis;
+  /** Grow to fill available space (flex contexts) */
+  flex?: boolean;
+  className?: string;
+}
+
+const sizeMap: Record<SpacerSize, string> = {
+  1:  '0.25rem',
+  2:  '0.5rem',
+  3:  '0.75rem',
+  4:  '1rem',
+  5:  '1.25rem',
+  6:  '1.5rem',
+  8:  '2rem',
+  10: '2.5rem',
+  12: '3rem',
+  16: '4rem',
+  20: '5rem',
+  24: '6rem',
+  32: '8rem',
+};
+
+export const Spacer: React.FC<SpacerProps> = ({
+  size = 4,
+  axis = 'vertical',
+  flex = false,
+  className = '',
+}) => {
+  const value = sizeMap[size];
+
+  const style: React.CSSProperties = flex
+    ? { flex: '1 1 auto' }
+    : {
+        display: 'block',
+        width:  axis === 'horizontal' || axis === 'both' ? value : undefined,
+        height: axis === 'vertical'   || axis === 'both' ? value : undefined,
+        minWidth:  axis === 'horizontal' || axis === 'both' ? value : undefined,
+        minHeight: axis === 'vertical'   || axis === 'both' ? value : undefined,
+      };
+
+  return (
+    <span
+      aria-hidden="true"
+      data-testid="spacer"
+      style={style}
+      className={className}
+    />
+  );
+};


### PR DESCRIPTION
Closes #312, 
closes #314, 
closes #315, 
closes #316

Implements four missing frontend layout components for the NEPA platform design system.

Grid / GridItem — responsive CSS grid wrapper with per-breakpoint column control (cols, colsSm, colsMd, colsLg, colsXl), independent gap axes (gap, gapX, gapY), and a companion GridItem with responsive span props (span, spanSm, spanMd, spanLg, spanXl). Both support a polymorphic as prop for semantic HTML.

Divider — content separator with horizontal and vertical orientations, three border styles (solid, dashed, dotted), three weights (thin, base, thick), and an optional inline label with start/center/end alignment. Includes role="separator" and aria-orientation for full accessibility.

Spacer — whitespace utility that maps directly to the design system spacing scale (1–32). Supports vertical, horizontal, and both axes, plus a flex mode that expands to fill available space in flex containers. Rendered as aria-hidden so it's invisible to screen readers.

Container — page-level layout wrapper with six max-width presets (sm → 2xl → full), four responsive padding levels, optional centering via mx-auto, and a polymorphic as prop for semantic landmarks (main, section, etc.).

All components follow existing project conventions (named exports, React.FC<Props>, Tailwind + CSS design system tokens) and include full test coverage via React Testing Library.