### PR TITLE
fix: Remove duplicate viewport meta tag and allow zooming for accessibility (Closes #425)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,20 +17,19 @@
     <!-- Basic Meta Tags -->
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <!-- Accessibility: Allow zooming up to 5x for users with visual impairments -->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, viewport-fit=cover" />
     <meta name="theme-color" content="#2563eb" />
-    <meta name="description" content="NEPA - Nigeria Electricity Payment System" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="apple-mobile-web-app-title" content="NEPA" />
-    <title>NEPA - Nigeria Electricity Payment System</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="NEPA - National Electricity Payment Assistant. Simplify your electricity bill payments with secure, fast, and convenient online payment solutions." />
     <meta name="keywords" content="electricity bill payment, NEPA, power billing, online payment, utility bills, Nigeria electricity, prepaid meters, postpaid billing" />
     <meta name="author" content="NEPA" />
     <meta name="robots" content="index, follow" />
     <meta name="language" content="English" />
     <meta name="revisit-after" content="7 days" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="NEPA" />
+    <title>NEPA - National Electricity Payment Assistant | Pay Electricity Bills Online</title>
     
     <!-- Open Graph Tags -->
     <meta property="og:title" content="NEPA - National Electricity Payment Assistant" />
@@ -133,7 +132,6 @@
     }
     </script>
     
-    <title>NEPA - National Electricity Payment Assistant | Pay Electricity Bills Online</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
Fixes duplicate viewport meta tags and enables zooming for accessibility (WCAG 1.4.4).

## Changes
- Removed duplicate viewport meta tag (two were present in index.html)
- Changed maximum-scale from 1.0 to 5.0 to allow user zooming
- Removed user-scalable=no (accessibility: users with visual impairments need zoom)
- Removed duplicate description and title tags
- Consolidated meta tags into a clean single set

## Testing
- HTML only change — no tests affected
- ESLint: N/A (HTML file)
- TypeScript: N/A

Closes #425